### PR TITLE
chore(ci): pin pre-commit dev toolchain and add dev_install.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - name: Install pre-commit
-        run: pip install pre-commit
+          cache-dependency-path: tools/requirements-dev.txt
+      - name: Install pinned dev toolchain
+        run: pip install -r tools/requirements-dev.txt
       - name: Run pre-commit on all files
         run: pre-commit run --all-files --show-diff-on-failure
 

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ scripts/issue_grinder_prompt.sh
 scripts/*.sh
 !scripts/hooks/*.sh
 !scripts/bootstrap_issues.sh
+!scripts/dev_install.sh

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -129,7 +133,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 107
       }
     ],
     "deploy/k3s/10-gateway.yaml": [
@@ -151,5 +155,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-16T16:09:24Z"
+  "generated_at": "2026-04-16T17:23:11Z"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,16 +25,11 @@ cd Afya-Sahihi
 # macOS: brew install python@3.12 uv
 # Linux: see https://docs.astral.sh/uv/
 
-# Install pre-commit and activate all hook types
-pip install pre-commit
-pre-commit install --install-hooks
-pre-commit install --hook-type pre-push
-pre-commit install --hook-type commit-msg
-
-# Initialize the secrets baseline (if it does not exist yet)
-if [ ! -f .secrets.baseline ]; then
-  detect-secrets scan > .secrets.baseline
-fi
+# Install pinned dev tooling and activate all hook types.
+# The wrapper installs pre-commit + detect-secrets at the exact versions
+# CI uses (see tools/requirements-dev.txt), then wires up the three hook
+# types the repo expects (pre-commit, pre-push, commit-msg).
+scripts/dev_install.sh
 
 # Install backend dependencies
 cd backend

--- a/scripts/dev_install.sh
+++ b/scripts/dev_install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# One-time developer environment bootstrap for Afya Sahihi.
+#
+# Installs pinned dev tools (pre-commit, detect-secrets) from
+# tools/requirements-dev.txt and activates all three pre-commit hook types
+# in the current clone.
+#
+# Usage:
+#   scripts/dev_install.sh
+#
+# Exits non-zero on the first failure so a contributor cannot proceed with
+# a partially-initialised environment — clinical codebases fail closed.
+set -euo pipefail
+
+# Resolve the repo root so the script works no matter where it is invoked from.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required on PATH" >&2
+  exit 1
+fi
+
+# Enforce Python 3.12 so the dev toolchain matches the runtime pin
+# declared in skills/afya-sahihi-principal/SKILL.md §1.
+if ! python3 -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3, 12) else 1)'; then
+  echo "error: Python 3.12+ is required; see CONTRIBUTING.md §'One-time setup per clone'" >&2
+  exit 1
+fi
+
+# If run outside a virtualenv on a PEP-668-managed system (Debian, Ubuntu,
+# Homebrew) pip will refuse. Surface that up front with a useful pointer
+# instead of failing later with a confusing externally-managed error.
+if [ -z "${VIRTUAL_ENV:-}" ] && [ -z "${CI:-}" ]; then
+  echo "warn: no VIRTUAL_ENV set; if pip refuses with 'externally-managed-environment'," >&2
+  echo "      activate a venv first (uv venv && source .venv/bin/activate)" >&2
+fi
+
+python3 -m pip install --upgrade --quiet pip
+python3 -m pip install --quiet -r tools/requirements-dev.txt
+
+pre-commit install --install-hooks
+pre-commit install --hook-type pre-push
+pre-commit install --hook-type commit-msg
+
+if [ ! -f .secrets.baseline ]; then
+  echo "info: creating .secrets.baseline"
+  detect-secrets scan > .secrets.baseline
+fi
+
+echo "ok: developer environment ready"

--- a/tools/requirements-dev.txt
+++ b/tools/requirements-dev.txt
@@ -1,0 +1,14 @@
+# Developer toolchain for Afya Sahihi.
+#
+# Everything in this file is used only to run pre-commit, not at runtime. Pin
+# exact versions so every contributor and the CI hygiene job agree on which
+# hook versions execute. Update deliberately; the hook versions in
+# `.pre-commit-config.yaml` are kept in step with these.
+#
+# Install with:
+#   pip install -r tools/requirements-dev.txt
+# or via the wrapper:
+#   scripts/dev_install.sh
+
+pre-commit==4.5.1
+detect-secrets==1.5.0


### PR DESCRIPTION
Closes #4

## Summary
Issue #4 asks for pre-commit to be installed as a dev dependency, for CONTRIBUTING.md to document the install ritual, and for CI to run `pre-commit run --all-files --show-diff-on-failure`. The hooks already execute today, but `pre-commit` itself was installed unpinned (`pip install pre-commit`) in both CONTRIBUTING and the hygiene CI job. A future minor release that shifts hook protocol or yaml schema would silently diverge local dev from CI — bad for a clinical codebase where reproducibility gates safety.

This PR:
- Adds `tools/requirements-dev.txt` with `pre-commit==4.5.1` and `detect-secrets==1.5.0` pinned to the versions CI and the maintainer machine use today.
- Adds `scripts/dev_install.sh` that installs the pinned toolchain, wires all three hook types (pre-commit, pre-push, commit-msg), and seeds `.secrets.baseline` if missing. Fails closed on any step.
- Replaces the four-command install block in `CONTRIBUTING.md` with a single `scripts/dev_install.sh` invocation.
- Fixes the hygiene CI job to install from the pinned file and points `cache-dependency-path` at it (the root had no `requirements.txt` for `cache: pip` to key on, which was causing the hygiene job to error before the hooks even ran).

## Acceptance criteria verification
- [x] **`pre-commit run --all-files` passes on main** — PASS. Verified locally on this branch; same hook set as main; only files-to-check difference is the new wrapper script (which shellcheck passed via the pre-commit hook). See commit `26d5eea`.
- [x] **CONTRIBUTING.md documents the install ritual** — PASS. §"One-time setup per clone" now references `scripts/dev_install.sh`, which runs `pre-commit install --install-hooks`, `pre-commit install --hook-type pre-push`, and `pre-commit install --hook-type commit-msg` — the exact commands the issue proposal lists.
- [x] **CI runs `pre-commit run --all-files --show-diff-on-failure`** — PASS. `.github/workflows/ci.yml` §`hygiene` job still runs that exact command, now with a pinned install.

## Test plan
- Manual: ran `pre-commit run --all-files` on branch — all configured hooks pass or skip with no-files.
- Manual: ran `bash -n scripts/dev_install.sh` for syntax; shellcheck validated via the `shellcheck` pre-commit hook.
- CI: the hygiene job on this PR will prove the cache-dependency-path fix works; previous PRs errored at `actions/setup-python@v5` because no `requirements.txt` existed at the root.

## Deployment notes
None. Developer-tooling-only change. No runtime dependencies, no env vars, no migrations, no secrets. Contributors with existing clones should re-run `scripts/dev_install.sh` to upgrade to pinned `pre-commit==4.5.1`.