### PR TITLE
feat(ci): close pr-automation gaps (observability label, ready-for-review welcome)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,6 +47,13 @@
 - changed-files:
   - any-glob-to-any-file: ["deploy/**/*"]
 
+"area/observability":
+- changed-files:
+  - any-glob-to-any-file:
+    - "backend/app/observability/**/*"
+    - "deploy/observability/**/*"
+    - "deploy/k3s/observability/**/*"
+
 "area/env":
 - changed-files:
   - any-glob-to-any-file: ["env/**/*"]

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -98,4 +98,8 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body,
             });
-        if: github.event.action == 'opened'
+        # Fire on first open for normal PRs, and also when a draft is
+        # marked ready-for-review (the `opened` event does not re-fire on
+        # that transition). Edits and synchronizes stay quiet so the PR
+        # author is not spammed on every push.
+        if: github.event.action == 'opened' || github.event.action == 'ready_for_review'

--- a/docs/runbooks/ci-branch-protection.md
+++ b/docs/runbooks/ci-branch-protection.md
@@ -27,6 +27,10 @@ The checks that must be green before merge to `main`:
 | `Tier 1 evals (Inspect AI)` | golden-set regression (self-skips pre-M6) |
 | `Frontend lint + typecheck + tests` | self-skips until #35 lands |
 | `Validate k3s manifests` | kubeconform + kyverno |
+| `Auto-label by paths` | labels PRs by file path for CODEOWNERS routing |
+| `PR size check` | fails the PR when >1000 lines changed (enforces the size cap) |
+| `PR checklist filled out` | PR body must tick the reviewer checklist |
+| `Lint PR title (conventional)` | enforces Conventional Commit title format |
 
 `Container build + vulnerability scan` is intentionally omitted — it only
 runs on `push` after merge, so it cannot be a merge gate.
@@ -48,6 +52,10 @@ gh api \
   -f 'required_status_checks[contexts][]=Tier 1 evals (Inspect AI)' \
   -f 'required_status_checks[contexts][]=Frontend lint + typecheck + tests' \
   -f 'required_status_checks[contexts][]=Validate k3s manifests' \
+  -f 'required_status_checks[contexts][]=Auto-label by paths' \
+  -f 'required_status_checks[contexts][]=PR size check' \
+  -f 'required_status_checks[contexts][]=PR checklist filled out' \
+  -f 'required_status_checks[contexts][]=Lint PR title (conventional)' \
   -f 'enforce_admins=true' \
   -f 'required_pull_request_reviews[required_approving_review_count]=1' \
   -f 'required_pull_request_reviews[dismiss_stale_reviews]=true' \


### PR DESCRIPTION
Closes #8

## Summary
Issue #8's four acceptance criteria are already exercised today by `.github/workflows/pr-automation.yml`:
- Auto-label by paths: fired on every recent PR (#40–#43).
- PR size check with `size/xl` failure on >1000 lines: `fail_if_xl: 'true'`.
- Checklist completeness: `mheap/require-checklist-action@v2`.
- Non-conventional title lint: `amannn/action-semantic-pull-request@v5`.
- Welcome comment on open: `actions/github-script@v7`.

Three concrete gaps, surfaced while verifying:

1. **`area/observability` missing from the labeler.** Issues #30, #31, #32, #36 use that label; a PR touching `backend/app/observability/` or `deploy/observability/` today would only get `area/backend` + `area/deploy`, so CODEOWNERS would not route it to the observability reviewer group once that group exists. Rule added covering the three canonical paths.
2. **Welcome comment never fires for draft → ready transitions.** `if: github.event.action == 'opened'` means a PR opened as draft and later marked ready-for-review silently skips the checklist reminder. Extended to also fire on `ready_for_review`; edit/synchronize still suppressed to avoid spam.
3. **Branch-protection runbook (landed with #7) did not list the PR-automation checks.** Issue #8 acceptance says `size/xl` must block merge — that only works if branch protection marks `PR size check` required. Added the four pr-automation contexts to `docs/runbooks/ci-branch-protection.md` table and the `gh api` command.

## Acceptance criteria verification
- [x] **All automation runs on a new draft PR** — PASS. `on: pull_request: types: [opened, edited, synchronize, ready_for_review]` covers draft PRs (GitHub fires `pull_request` for drafts by default). `request-reviewers` correctly short-circuits inside the script when `pull_request.draft === true` so the welcome comment doesn't fire until ready-for-review. The other four jobs run on drafts. Confirmed on PRs #40/#41/#42/#43.
- [x] **Labels apply correctly per file path** — PASS. `.github/labeler.yml` has rules for every area label used by issues #4–#39. The new `area/observability` rule closes the last gap.
- [x] **`size/xl` blocks merge** — PASS at the workflow level (`fail_if_xl: 'true'`). Blocks merge once branch protection includes `PR size check` as required — runbook updated.
- [x] **Non-conventional titles are flagged** — PASS. `amannn/action-semantic-pull-request@v5` has fired on every PR in this session; it blocks merge with the same branch-protection mechanism.

## Test plan
- Manual: yamllint clean on both workflow and labeler (`pre-commit run --all-files` green).
- Behavioral: recent PRs #40–#43 confirm all 5 jobs run on the standard PR flow. The `area/observability` rule and `ready_for_review` trigger take effect on the next PR that matches their paths/actions.

## Deployment notes
None runtime. Admin follow-up: re-run the `gh api` block in `docs/runbooks/ci-branch-protection.md` §1 after merge; the previous version in that runbook omitted the four pr-automation contexts, so branch protection (once enabled) will not yet gate on size/xl or conventional-title lint.