### PR TITLE
feat(ci): group github-actions bumps, add Dependabot activation runbook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,8 @@ updates:
     labels:
       - "area/ci"
       - "type/chore"
+    reviewers:
+      - AmosBunde
     groups:
       # Batch action-version bumps so we do not get one PR per action
       # (three sat open for seven hours before this grouping landed).
@@ -86,6 +88,8 @@ updates:
     labels:
       - "area/labeling-ui"
       - "type/chore"
+    reviewers:
+      - AmosBunde
 
   # Eval harness
   - package-ecosystem: pip
@@ -97,6 +101,8 @@ updates:
     labels:
       - "area/eval"
       - "type/chore"
+    reviewers:
+      - AmosBunde
     ignore:
       # Inspect AI is pinned for reproducibility of eval results
       - dependency-name: "inspect-ai"
@@ -111,6 +117,8 @@ updates:
       - "area/deploy"
       - "type/chore"
       - "touches-security"
+    reviewers:
+      - AmosBunde
   - package-ecosystem: docker
     directory: "/frontend"
     schedule:
@@ -119,6 +127,8 @@ updates:
       - "area/deploy"
       - "type/chore"
       - "touches-security"
+    reviewers:
+      - AmosBunde
   - package-ecosystem: docker
     directory: "/labeling"
     schedule:
@@ -127,3 +137,5 @@ updates:
       - "area/deploy"
       - "type/chore"
       - "touches-security"
+    reviewers:
+      - AmosBunde

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,18 @@ updates:
     labels:
       - "area/ci"
       - "type/chore"
+    groups:
+      # Batch action-version bumps so we do not get one PR per action
+      # (three sat open for seven hours before this grouping landed).
+      security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
+      minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      major:
+        applies-to: version-updates
+        update-types: ["major"]
 
   # Labeling UI (Streamlit)
   - package-ecosystem: pip

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,7 @@ all you need.
 |---------|---------|
 | [bootstrap.md](./bootstrap.md) | First-time cluster bootstrap from bare metal to first green canary |
 | [ci-branch-protection.md](./ci-branch-protection.md) | Configure CI branch protection and Codecov integration |
+| [ci-dependabot.md](./ci-dependabot.md) | Enable Dependabot vulnerability alerts and weekly triage procedure |
 
 ## Authoring guidelines
 

--- a/docs/runbooks/ci-dependabot.md
+++ b/docs/runbooks/ci-dependabot.md
@@ -65,6 +65,12 @@ log.
 3. **Major bumps individually.** Each one gets a full review. Link the
    upstream changelog and the ADR that originally justified the dependency.
 
+> **Convention note**: the `NO-ADR-NEEDED: ...` marker above is a human
+> triage convention only. No hook or action parses it — it exists so a
+> reviewer reading the PR body can see at a glance that the author
+> considered and dismissed the ADR question. Do not build tooling that
+> depends on the exact string.
+
 ### Expected labels on every Dependabot PR
 
 The `actions/labeler@v5` in `pr-automation.yml` applies labels by changed

--- a/docs/runbooks/ci-dependabot.md
+++ b/docs/runbooks/ci-dependabot.md
@@ -1,0 +1,103 @@
+# Runbook: Dependabot activation and triage
+
+**When to use**: on first repo setup to enable vulnerability alerts and
+automated security updates, and weekly to triage the batch of Dependabot
+PRs that lands Monday 06:00 Africa/Nairobi.
+
+**Blast radius**: toggles are repo-wide. Enabling alerts cannot leak private
+information but disabling them silently hides CVE data. Merging a Dependabot
+PR that upgrades a load-bearing dependency can break CI; review like any
+other PR — the changelog is not a substitute for the test suite.
+
+**Who runs this**: repository admin for §1. Any maintainer for §2.
+
+## 1. One-time admin setup
+
+Dependabot opens update PRs on its own schedule as soon as
+`.github/dependabot.yml` is on `main`. GitHub-side vulnerability alerts
+and automated security fixes are separate toggles that default to off.
+
+```bash
+# Enable vulnerability alerts (GitHub surfaces CVE warnings in PRs and
+# the Security tab)
+gh api --method PUT \
+  /repos/AmosBunde/Afya-Sahihi/vulnerability-alerts
+
+# Enable automated security fixes (Dependabot opens CVE-fix PRs without
+# waiting for the weekly schedule)
+gh api --method PUT \
+  /repos/AmosBunde/Afya-Sahihi/automated-security-fixes
+```
+
+Verify:
+
+```bash
+# 404 with message "Vulnerability alerts are disabled." means off.
+# 204 No Content means on.
+gh api /repos/AmosBunde/Afya-Sahihi/vulnerability-alerts
+```
+
+## 2. Weekly triage (Monday morning)
+
+Dependabot opens PRs grouped by ecosystem and update type. The repo's
+`dependabot.yml` batches:
+
+- `security-updates` — one PR covering every CVE fix across packages.
+- `minor-and-patch` — one PR per ecosystem grouping minor and patch bumps.
+- `major` (github-actions only) — one PR per major bump because each
+  deserves an individual review.
+
+Expected cadence: 1–4 PRs per Monday. A week with more than 4 Dependabot
+PRs usually means `dependabot.yml` grouping has broken; check the CI job
+log.
+
+### Triage order
+
+1. **Security updates first.** If a `security-updates` PR exists, review
+   and merge it the same day unless the upgrade is known to break CI.
+2. **Minor-and-patch next.** Group review — if CI is green, merge. The
+   `check_adr_for_new_dep.sh` hook fires on any `+` line in
+   `backend/pyproject.toml` / `backend/requirements.txt`, so an upgrade PR
+   that changes a pinned version will still require an ADR-related
+   justification in the PR body. For patch-only bumps, write
+   `NO-ADR-NEEDED: version bump within existing ADR window` in the body
+   to document the rationale.
+3. **Major bumps individually.** Each one gets a full review. Link the
+   upstream changelog and the ADR that originally justified the dependency.
+
+### Expected labels on every Dependabot PR
+
+The `actions/labeler@v5` in `pr-automation.yml` applies labels by changed
+path:
+
+- `backend/pyproject.toml` / `backend/requirements.txt` → `area/backend`,
+  `needs-adr`
+- `frontend/package-lock.json` → `area/frontend`
+- `.github/workflows/*.yml` → `area/ci`
+- `backend/Dockerfile` → `area/deploy`, `touches-security`
+
+The `needs-adr` label fires on every pip-ecosystem Dependabot PR because
+the underlying file changed. That is intentional; the PR reviewer should
+either cite an existing ADR or mark it NO-ADR-NEEDED as described above.
+
+## 3. Ignored packages
+
+Some packages are pinned for operational reasons; Dependabot will not
+open upgrade PRs for them. See `.github/dependabot.yml`:
+
+- `vllm` — pinned for H100 stability; upgrades require planned maintenance.
+- `pydantic` — no major-version bumps (v2 API stable).
+- `inspect-ai` — no major or minor bumps (reproducibility of eval results).
+
+When any of these needs an upgrade, open a manual PR and link the
+reproducibility justification in the body.
+
+## Verify checklist
+
+- [ ] `gh api /repos/AmosBunde/Afya-Sahihi/vulnerability-alerts` returns
+      HTTP 204 (enabled).
+- [ ] `Security → Dependabot` in the GitHub UI lists zero open alerts OR
+      an open PR addressing each.
+- [ ] Weekly Dependabot PR count ≤ 4; if higher, grouping is broken.
+- [ ] Every Dependabot PR has an assigned reviewer (auto-assigned via
+      `reviewers: [AmosBunde]` in `dependabot.yml`).


### PR DESCRIPTION
Closes #10

## Summary
Issue #10 asks for Dependabot across pip, npm, github-actions, and docker, plus proof of at least one PR and evidence that security alerts fire. Verification against the current repo state surfaced three concrete findings:

1. **Four ecosystems already configured** in `.github/dependabot.yml` (pip for /backend, /labeling, /eval; npm for /frontend; github-actions for root; docker for /backend, /frontend, /labeling). Nothing missing.
2. **Three Dependabot PRs already open** (#1, #2, #3 — astral-sh/setup-uv 4→7, actions/github-script 7→9, codecov/codecov-action 4→6). Acceptance #1 is met. But they opened as three separate PRs because the github-actions ecosystem lacked a `groups:` block. Added `security-updates`/`minor-and-patch`/`major` groups matching the pip and npm ecosystems.
3. **Vulnerability alerts are disabled** on the repo (`gh api /vulnerability-alerts` → HTTP 404 "disabled"). That is admin-API scope and cannot be set by a config file. Added `docs/runbooks/ci-dependabot.md` with the two `gh api` PUT calls for a repo admin to run, plus a weekly-triage procedure so Monday morning PRs aren't re-invented each week.

## Acceptance criteria verification
- [x] **Dependabot opens at least one PR against the new config** — PASS. PRs #1, #2, #3 are open github-actions upgrades as of 2026-04-16 16:24 UTC.
- [x] **Security alerts fire on GitHub** — DOCUMENTED. Currently disabled (confirmed via `gh api`). Runbook §1 has the two `gh api PUT` commands. Admin follow-up required post-merge; flagged in deployment notes.
- [x] **ADR-requiring updates correctly flagged** — PASS via two overlapping mechanisms: (a) Dependabot pip ecosystem applies `needs-adr` directly, (b) `actions/labeler@v5` in `pr-automation.yml` applies it on any `backend/pyproject.toml` / `backend/requirements.txt` diff. Runbook §2 documents the `NO-ADR-NEEDED: version bump within existing ADR window` rationale convention for reviewers of patch bumps.

## Test plan
- `pre-commit run --all-files` — green (yamllint passes on both modified files).
- Manual verification: `gh pr list --author app/dependabot` confirms the three open Dependabot PRs.
- Grouping behaviour will self-verify on the next Monday 06:00 EAT Dependabot run; if `security-updates`/`minor-and-patch`/`major` groups are respected, we should see at most one github-actions PR per category next week.

## Deployment notes
Admin follow-up: run the two commands in `docs/runbooks/ci-dependabot.md` §1 (`PUT /vulnerability-alerts` and `PUT /automated-security-fixes`). Acceptance item #2 is not fully live until this is done; runbook is the handoff artefact.