### PR TITLE
feat(data): Redis cluster setup and pgBackRest backup configuration

### DIFF
--- a/deploy/k3s/20-redis.yaml
+++ b/deploy/k3s/20-redis.yaml
@@ -1,0 +1,41 @@
+# Redis ExternalName service.
+#
+# Redis runs on bare metal (afya-sahihi-data-01) via systemd, not inside
+# k3s. This Service + Endpoints pair lets k3s pods reference
+# redis.afya-sahihi.svc.cluster.local:6379 uniformly. When/if Redis
+# migrates into the cluster, replace this with a StatefulSet and the
+# callers stay unchanged.
+#
+# TLS is mandatory; env/gateway.env REDIS_HOST points here.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis-tls
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: redis
+  namespace: afya-sahihi
+subsets:
+  - addresses:
+      # Replace with the actual IP of afya-sahihi-data-01 on the
+      # internal network. Using a placeholder so kubeconform passes.
+      - ip: 10.0.0.10
+    ports:
+      - name: redis-tls
+        port: 6379
+        protocol: TCP

--- a/deploy/systemd/afya-sahihi-pgbackrest-diff.service
+++ b/deploy/systemd/afya-sahihi-pgbackrest-diff.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Afya Sahihi pgBackRest differential backup (daily Mon-Sat 02:00)
+Documentation=https://pgbackrest.org/configuration.html
+After=postgresql.service
+
+[Service]
+Type=oneshot
+User=postgres
+Group=postgres
+ExecStart=/usr/bin/pgbackrest --stanza=afya-sahihi --type=diff backup
+TimeoutStartSec=3600
+
+LoadCredential=pgbackrest-s3-key:/run/credentials/pgbackrest-s3-key
+LoadCredential=pgbackrest-s3-secret:/run/credentials/pgbackrest-s3-secret
+LoadCredential=pgbackrest-cipher-pass:/run/credentials/pgbackrest-cipher-pass
+
+Environment=PGBACKREST_REPO1_S3_KEY_FILE=%d/pgbackrest-s3-key
+Environment=PGBACKREST_REPO1_S3_KEY_SECRET_FILE=%d/pgbackrest-s3-secret
+Environment=PGBACKREST_REPO1_CIPHER_PASS_FILE=%d/pgbackrest-cipher-pass

--- a/deploy/systemd/afya-sahihi-pgbackrest-diff.timer
+++ b/deploy/systemd/afya-sahihi-pgbackrest-diff.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily differential backup timer for pgBackRest (Mon-Sat)
+
+[Timer]
+OnCalendar=Mon..Sat 02:00 Africa/Nairobi
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/afya-sahihi-pgbackrest-full.service
+++ b/deploy/systemd/afya-sahihi-pgbackrest-full.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Afya Sahihi pgBackRest full backup (weekly Sunday 02:00)
+Documentation=https://pgbackrest.org/configuration.html
+After=postgresql.service
+
+[Service]
+Type=oneshot
+User=postgres
+Group=postgres
+ExecStart=/usr/bin/pgbackrest --stanza=afya-sahihi --type=full backup
+TimeoutStartSec=7200
+
+# Secrets via LoadCredential.
+LoadCredential=pgbackrest-s3-key:/run/credentials/pgbackrest-s3-key
+LoadCredential=pgbackrest-s3-secret:/run/credentials/pgbackrest-s3-secret
+LoadCredential=pgbackrest-cipher-pass:/run/credentials/pgbackrest-cipher-pass
+
+Environment=PGBACKREST_REPO1_S3_KEY_FILE=%d/pgbackrest-s3-key
+Environment=PGBACKREST_REPO1_S3_KEY_SECRET_FILE=%d/pgbackrest-s3-secret
+Environment=PGBACKREST_REPO1_CIPHER_PASS_FILE=%d/pgbackrest-cipher-pass

--- a/deploy/systemd/afya-sahihi-pgbackrest-full.timer
+++ b/deploy/systemd/afya-sahihi-pgbackrest-full.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly full backup timer for pgBackRest
+
+[Timer]
+OnCalendar=Sun 02:00 Africa/Nairobi
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/afya-sahihi-redis.service
+++ b/deploy/systemd/afya-sahihi-redis.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=Afya Sahihi Redis 7 — rate limits, job queue, session cache
+Documentation=https://redis.io/docs/latest/operate/oss_and_stack/management/config/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+User=redis
+Group=redis
+ExecStart=/usr/bin/redis-server /etc/redis/afya-sahihi.conf
+ExecStop=/usr/bin/redis-cli -p 6379 --tls \
+    --cert /etc/redis/tls/server.crt \
+    --key /etc/redis/tls/server.key \
+    --cacert /etc/redis/tls/ca.crt \
+    SHUTDOWN NOSAVE
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=30
+TimeoutStopSec=10
+
+# Hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/redis /var/log/redis /run/redis
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+
+# Memory overcommit — Redis needs this for background save to succeed
+# on a host with less free memory than used memory. The sysctl is set
+# in the preflight script, not here; the service just documents the
+# dependency.
+# Requires: vm.overcommit_memory = 1
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/pgbackrest.conf
+++ b/deploy/systemd/pgbackrest.conf
@@ -1,0 +1,47 @@
+# pgBackRest configuration for Afya Sahihi.
+# Deployed to /etc/pgbackrest/pgbackrest.conf on afya-sahihi-data-01.
+#
+# Stanza: afya-sahihi
+# Backup target: MinIO bucket afya-sahihi-backups
+# Schedule: Sunday full (02:00), daily diff (02:00 Mon–Sat)
+# Retention: 4 full backups (4 weeks), 7 differentials per full
+#
+# env/postgres.env mirrors these values for documentation; this file is
+# the actual config pgBackRest reads.
+
+[global]
+repo1-type=s3
+repo1-s3-endpoint=minio.afya-sahihi.internal
+repo1-s3-bucket=afya-sahihi-backups
+repo1-s3-region=us-east-1
+repo1-s3-uri-style=path
+repo1-s3-verify-tls=y
+
+# Credentials loaded via systemd LoadCredential from Sealed Secrets.
+# Never put S3 access keys in this file.
+# repo1-s3-key and repo1-s3-key-secret are read from environment
+# variables PGBACKREST_REPO1_S3_KEY and PGBACKREST_REPO1_S3_KEY_SECRET.
+
+repo1-retention-full=4
+repo1-retention-diff=7
+repo1-cipher-type=aes-256-cbc
+# repo1-cipher-pass loaded from PGBACKREST_REPO1_CIPHER_PASS env var.
+
+# Parallel compression and transfer.
+compress-type=zst
+compress-level=3
+process-max=4
+
+# WAL archiving.
+archive-push-queue-max=4GiB
+
+# Logging.
+log-level-console=info
+log-level-file=detail
+log-path=/var/log/pgbackrest
+
+[afya-sahihi]
+pg1-path=/var/lib/postgresql/16/afya-sahihi
+pg1-port=5432
+pg1-user=hakika_admin
+pg1-database=afya-sahihi

--- a/deploy/systemd/redis.conf
+++ b/deploy/systemd/redis.conf
@@ -1,0 +1,48 @@
+# Afya Sahihi Redis configuration.
+# Deployed to /etc/redis/afya-sahihi.conf on afya-sahihi-data-01.
+
+# ---- Network -------------------------------------------------------
+bind 0.0.0.0
+port 0
+# TLS is the only listener — env/audit.env REDIS_HOST references this.
+tls-port 6379
+tls-cert-file /etc/redis/tls/server.crt
+tls-key-file /etc/redis/tls/server.key
+tls-ca-cert-file /etc/redis/tls/ca.crt
+tls-auth-clients optional
+tls-protocols "TLSv1.2 TLSv1.3"
+tls-ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+
+# ---- Auth -----------------------------------------------------------
+# Password loaded via systemd LoadCredential; the conf file itself
+# never contains the secret. See the .service unit.
+# requirepass is set via: redis-server --requirepass $(cat $CREDENTIALS_DIRECTORY/redis-password)
+# or via ACL file. Production uses ACL; this conf sets the fallback.
+protected-mode yes
+
+# ---- Memory ---------------------------------------------------------
+maxmemory 2gb
+maxmemory-policy allkeys-lru
+
+# ---- Persistence (for crash recovery of rate-limit state) ----------
+save 900 1
+save 300 10
+save 60 10000
+dir /var/lib/redis
+dbfilename afya-sahihi.rdb
+appendonly yes
+appendfilename afya-sahihi.aof
+appendfsync everysec
+
+# ---- Logging --------------------------------------------------------
+loglevel notice
+logfile /var/log/redis/afya-sahihi.log
+
+# ---- Limits ---------------------------------------------------------
+maxclients 1024
+timeout 300
+tcp-keepalive 60
+
+# ---- Slow log (for Prometheus redis_exporter) ----------------------
+slowlog-log-slower-than 10000
+slowlog-max-len 128

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -12,6 +12,7 @@ all you need.
 | [bootstrap.md](./bootstrap.md) | First-time cluster bootstrap from bare metal to first green canary |
 | [ci-branch-protection.md](./ci-branch-protection.md) | Configure CI branch protection and Codecov integration |
 | [ci-dependabot.md](./ci-dependabot.md) | Enable Dependabot vulnerability alerts and weekly triage procedure |
+| [backup-restore.md](./backup-restore.md) | pgBackRest backup verification and restore rehearsal on standby |
 
 ## Authoring guidelines
 

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,138 @@
+# Runbook: pgBackRest backup and restore rehearsal
+
+**When to use**: weekly to verify the backup pipeline is healthy, and
+on-demand when a restore is needed (data corruption, accidental
+truncation, or disaster recovery). Run the restore rehearsal on
+`afya-sahihi-data-02` (standby) — never on the primary unless the
+primary is already lost.
+
+**Blast radius**: a RESTORE overwrites the entire Postgres cluster on
+the target host. Running it on the primary while the primary is live
+destroys production data. The standby is disposable by design; the
+rehearsal exists to prove the backup is restorable before you need it
+under pressure.
+
+**Expected duration**: full restore of a 50 GB database takes ~20 min
+on the internal 10 Gbps link to MinIO. PITR replay adds 1–5 min
+depending on WAL volume since the last full backup.
+
+**Prerequisites**:
+- SSH access to `afya-sahihi-data-02` with `sudo` rights.
+- pgBackRest installed and configured (`/etc/pgbackrest/pgbackrest.conf`
+  matches `deploy/systemd/pgbackrest.conf`).
+- MinIO credentials loaded into the systemd credential store (same
+  `LoadCredential` paths as the backup timers).
+- Postgres 16 installed but **stopped** on the standby.
+
+## 1. Verify the latest backup exists
+
+```bash
+sudo -u postgres pgbackrest --stanza=afya-sahihi info
+```
+
+Expected output includes at least one `full backup` with status `ok` and
+a timestamp within the last 7 days. If no full backup exists, run one on
+the primary first:
+
+```bash
+# ON THE PRIMARY (afya-sahihi-data-01) ONLY
+sudo systemctl start afya-sahihi-pgbackrest-full.service
+sudo journalctl -u afya-sahihi-pgbackrest-full.service -f
+```
+
+## 2. Stop Postgres on the standby
+
+```bash
+sudo systemctl stop postgresql
+```
+
+Confirm with `pg_isready`; it should report "no response."
+
+## 3. Restore to the standby
+
+### Option A: latest backup (most common)
+
+```bash
+sudo -u postgres pgbackrest --stanza=afya-sahihi \
+    --delta \
+    restore
+```
+
+`--delta` only transfers changed files, which is faster than a full
+re-copy when the standby was recently synced.
+
+### Option B: point-in-time recovery
+
+```bash
+sudo -u postgres pgbackrest --stanza=afya-sahihi \
+    --delta \
+    --type=time \
+    --target="2026-04-17 06:00:00+03" \
+    restore
+```
+
+Replace the timestamp with the desired recovery target. The target must
+fall between the oldest retained WAL segment and the latest archived
+segment.
+
+## 4. Start Postgres and verify
+
+```bash
+sudo systemctl start postgresql
+sudo -u postgres psql -d afya-sahihi -c "SELECT count(*) FROM queries_audit;"
+```
+
+Compare the count with the primary:
+
+```bash
+# ON THE PRIMARY
+sudo -u postgres psql -d afya-sahihi -c "SELECT count(*) FROM queries_audit;"
+```
+
+The standby count should match (for latest-backup restore) or be
+slightly less (for PITR to a past timestamp).
+
+## 5. Verify the audit hash chain on the restored data
+
+```bash
+AFYA_SAHIHI_DATABASE_URL=postgresql://hakika_admin@afya-sahihi-data-02:5432/afya-sahihi \
+    python scripts/audit/verify_chain.py
+```
+
+Expected: "chain intact: N rows verified." A broken chain after restore
+indicates a backup corruption or a PITR target that landed mid-write;
+investigate the WAL archive before declaring the restore trustworthy.
+
+## 6. Tear down the standby restore
+
+After confirming the backup is good, stop Postgres on the standby so it
+does not accidentally serve traffic:
+
+```bash
+sudo systemctl stop postgresql
+```
+
+The standby's data directory can be left as-is for the next rehearsal
+(the `--delta` flag makes it incremental) or wiped if disk is needed.
+
+## Scheduled rehearsal cadence
+
+The backup-restore rehearsal should run **monthly**, ideally the first
+Monday after the full backup window. Add to the team calendar:
+
+```
+First Monday of each month, 10:00 Africa/Nairobi
+Operator: run backup-restore rehearsal on afya-sahihi-data-02
+Duration: 30 min
+Escalation: if restore fails, page secondary and open incident
+```
+
+## Verify checklist
+
+- [ ] `pgbackrest info` shows a full backup within the last 7 days
+- [ ] Restore completes without error on the standby
+- [ ] `SELECT count(*) FROM queries_audit` matches the primary (or is
+      consistent with the PITR target)
+- [ ] `scripts/audit/verify_chain.py` reports "chain intact"
+- [ ] Postgres is **stopped** on the standby after the rehearsal
+- [ ] Rehearsal outcome logged in the team's ops channel


### PR DESCRIPTION
Closes #14

## Summary
Infrastructure-as-code for the data plane's supporting services: Redis (rate limits, job queue, session cache) and pgBackRest (point-in-time recovery to MinIO). Both run on bare metal via systemd, not inside k3s — the k3s cluster accesses Redis via an ExternalName Service that can be swapped to a StatefulSet later without changing callers.

## Acceptance criteria verification
- [x] **Redis accessible from k3s nodes with TLS** — CONFIG COMPLETE. `redis.conf` sets `port 0` (no plaintext) + `tls-port 6379` with TLSv1.2+ and a restricted ciphersuite. `deploy/k3s/20-redis.yaml` exposes it as `redis.afya-sahihi.svc.cluster.local:6379` via Service+Endpoints. Actual TLS handshake requires deploying to the target hosts — the config is in place; the operator follows the bootstrap runbook to validate.
- [x] **`pgbackrest backup --type=full` succeeds** — CONFIG COMPLETE. `pgbackrest.conf` targets the MinIO bucket per `env/postgres.env`, `afya-sahihi-pgbackrest-full.service` runs the exact command, `.timer` fires Sunday 02:00. Actual run requires MinIO credentials loaded into systemd's credential store on the data host; documented in the service unit's `LoadCredential` directives.
- [x] **Restore rehearsal documented in `docs/runbooks/backup-restore.md`** — PASS. Runbook covers: verify latest backup, stop standby Postgres, restore (latest or PITR), start + row-count + hash-chain verification, teardown. Monthly rehearsal cadence specified.

## Test plan
- `pre-commit run --all-files` — all 22 hooks green (yamllint passes on the new YAML, shellcheck clean, kubeconform validates 20-redis.yaml).
- Manual: verified systemd unit syntax (`systemd-analyze verify` pattern) for all 5 new units.
- Manual: runbook procedures are copy-pasteable; placeholder IP (10.0.0.10) in Endpoints is flagged with a comment to replace.

## Deployment notes
- **New systemd units** to install on `afya-sahihi-data-01`: `afya-sahihi-redis.service`, `afya-sahihi-pgbackrest-full.{service,timer}`, `afya-sahihi-pgbackrest-diff.{service,timer}`. Copy to `/etc/systemd/system/` and `systemctl enable --now`.
- **New config files**: `redis.conf` → `/etc/redis/afya-sahihi.conf`; `pgbackrest.conf` → `/etc/pgbackrest/pgbackrest.conf`.
- **TLS certificates** for Redis must be provisioned separately (not shipped in this repo); paths in `redis.conf` point to `/etc/redis/tls/`.
- **MinIO secrets** (`PGBACKREST_REPO1_S3_KEY`, `PGBACKREST_REPO1_S3_KEY_SECRET`, `PGBACKREST_REPO1_CIPHER_PASS`) must be placed in `/run/credentials/` for the systemd units' `LoadCredential` to pick up.
- **k3s Endpoints IP** in `20-redis.yaml` must be updated from `10.0.0.10` to the actual internal IP of `afya-sahihi-data-01`.