### PR TITLE
feat(orchestrator): explicit state machine under 400 lines

### DIFF
--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,0 +1,35 @@
+"""Typed error hierarchy for the orchestrator pipeline.
+
+Every error carries a `reason` string and an optional `detail` object.
+The API layer maps each subclass to an appropriate HTTP response without
+a big isinstance ladder. SKILL.md §6.
+"""
+
+from __future__ import annotations
+
+
+class PipelineError(Exception):
+    """Base for any error in the orchestrator pipeline. Always fails closed."""
+
+    def __init__(self, reason: str, detail: object = None) -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(reason)
+
+
+class ValidationFailed(PipelineError): ...
+
+
+class PrefilterRejected(PipelineError): ...
+
+
+class RetrievalFailed(PipelineError): ...
+
+
+class GenerationFailed(PipelineError): ...
+
+
+class StrictReviewRejected(PipelineError): ...
+
+
+class ConformalFailed(PipelineError): ...

--- a/backend/app/orchestrator.py
+++ b/backend/app/orchestrator.py
@@ -1,0 +1,210 @@
+"""Typed, explicit pipeline. No framework magic.
+
+Every step is a method on this class. Each method takes a PipelineState,
+does one thing, and returns a new PipelineState. The `run` method composes
+them in a fixed order. To debug, pickle the state at any step and inspect.
+
+ADR-0003: explicit state machine over LangGraph. SKILL.md §3.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Final, Protocol
+
+from opentelemetry import trace
+
+from app.errors import (
+    ConformalFailed,
+    GenerationFailed,
+    PipelineError,
+    PrefilterRejected,
+    RetrievalFailed,
+    StrictReviewRejected,
+)
+from app.state import (
+    ConformalResult,
+    GenerationResult,
+    PipelineState,
+    PrefilterResult,
+    RetrievalResult,
+    StrictReviewResult,
+    ValidatedQuery,
+)
+
+tracer = trace.get_tracer(__name__)
+
+STRICT_REVIEW_CATEGORIES: Final = frozenset(
+    {"dosing", "contraindication", "pediatric", "pregnancy"}
+)
+
+
+# ---- Client protocols (concrete impls land with issue #22) ---- #
+
+
+class VLLMClient(Protocol):
+    async def prefilter(self, text: str) -> PrefilterResult: ...
+    async def generate(
+        self,
+        *,
+        query: ValidatedQuery,
+        retrieved_chunks: object,
+        request_logprobs: bool,
+    ) -> GenerationResult: ...
+    async def strict_review(
+        self,
+        *,
+        generation: GenerationResult,
+        categories: list[str],
+    ) -> StrictReviewResult: ...
+
+
+class RetrievalClient(Protocol):
+    async def search(
+        self,
+        *,
+        query_text: str,
+        query_embedding: object,
+        top_k: int,
+        filters: object,
+    ) -> RetrievalResult: ...
+
+
+class ConformalClient(Protocol):
+    async def construct_set(
+        self,
+        *,
+        query: ValidatedQuery,
+        generation: GenerationResult,
+        retrieval: RetrievalResult,
+    ) -> ConformalResult: ...
+
+
+# ---- Orchestrator ---- #
+
+
+class Orchestrator:
+    """Typed, explicit pipeline. No framework magic.
+
+    Every arrow on the C4 Level 3 component diagram corresponds to a
+    method here. No DAG framework, no hidden behavior, no inheritance
+    hierarchy.
+    """
+
+    def __init__(
+        self,
+        *,
+        vllm_27b: VLLMClient,
+        vllm_4b: VLLMClient,
+        retrieval: RetrievalClient,
+        conformal: ConformalClient,
+        prefilter_threshold: float,
+        strict_review_enabled: bool,
+        fail_closed: bool,
+    ) -> None:
+        self._vllm_27b = vllm_27b
+        self._vllm_4b = vllm_4b
+        self._retrieval = retrieval
+        self._conformal = conformal
+        self._prefilter_threshold = prefilter_threshold
+        self._strict_review_enabled = strict_review_enabled
+        self._fail_closed = fail_closed
+
+    async def run(self, query: ValidatedQuery) -> PipelineState:
+        state = PipelineState(query=query)
+
+        with tracer.start_as_current_span("orchestrator.run") as span:
+            span.set_attribute("query.id", query.id)
+            span.set_attribute("query.language", query.language)
+
+            try:
+                state = await self._prefilter(state)
+                state = await self._retrieve(state)
+                state = await self._generate(state)
+                state = await self._strict_review(state)
+                state = await self._conformal(state)
+                return state
+            except PipelineError as e:
+                return replace(state, errors=state.errors + (e,))
+
+    async def _prefilter(self, state: PipelineState) -> PipelineState:
+        with tracer.start_as_current_span("orchestrator.prefilter") as span:
+            result = await self._vllm_4b.prefilter(state.query.text)
+            span.set_attribute("prefilter.score", result.topic_score)
+            span.set_attribute("prefilter.safety_flag", result.safety_flag)
+
+            if result.topic_score < self._prefilter_threshold or result.safety_flag:
+                raise PrefilterRejected(
+                    reason="topic_coherence_low" if not result.safety_flag else "safety_flag",
+                    detail=result,
+                )
+            return replace(state, prefilter_result=result)
+
+    async def _retrieve(self, state: PipelineState) -> PipelineState:
+        with tracer.start_as_current_span("orchestrator.retrieve") as span:
+            try:
+                result = await self._retrieval.search(
+                    query_text=state.query.text,
+                    query_embedding=None,
+                    top_k=6,
+                    filters=state.query.retrieval_filters,
+                )
+            except Exception as e:
+                raise RetrievalFailed(reason=str(e)) from e
+            span.set_attribute("retrieval.n_chunks", len(result.chunks))
+            span.set_attribute("retrieval.top1_similarity", result.top1_similarity)
+            return replace(state, retrieval_result=result)
+
+    async def _generate(self, state: PipelineState) -> PipelineState:
+        with tracer.start_as_current_span("orchestrator.generate") as span:
+            if state.retrieval_result is None:  # noqa: SIM108
+                raise GenerationFailed(reason="retrieval_result missing; pipeline out of order")
+            try:
+                result = await self._vllm_27b.generate(
+                    query=state.query,
+                    retrieved_chunks=state.retrieval_result.chunks,
+                    request_logprobs=True,
+                )
+            except Exception as e:
+                raise GenerationFailed(reason=str(e)) from e
+            span.set_attribute("generation.n_tokens", result.n_tokens)
+            span.set_attribute("generation.avg_logprob", result.avg_logprob)
+            return replace(state, generation_result=result)
+
+    async def _strict_review(self, state: PipelineState) -> PipelineState:
+        if not self._strict_review_enabled:
+            return state
+        if state.generation_result is None:
+            raise StrictReviewRejected(reason="generation_result missing; pipeline out of order")
+
+        categories = set(state.query.classified_categories or ())
+        if not (categories & STRICT_REVIEW_CATEGORIES):
+            return state
+
+        with tracer.start_as_current_span("orchestrator.strict_review") as span:
+            result = await self._vllm_27b.strict_review(
+                generation=state.generation_result,
+                categories=list(categories & STRICT_REVIEW_CATEGORIES),
+            )
+            span.set_attribute("strict_review.approved", result.approved)
+            if not result.approved:
+                raise StrictReviewRejected(reason=result.reason or "review_failed", detail=result)
+            return replace(state, strict_review_result=result)
+
+    async def _conformal(self, state: PipelineState) -> PipelineState:
+        with tracer.start_as_current_span("orchestrator.conformal") as span:
+            if state.generation_result is None or state.retrieval_result is None:
+                raise ConformalFailed(
+                    reason="generation or retrieval result missing; pipeline out of order"
+                )
+            try:
+                result = await self._conformal.construct_set(
+                    query=state.query,
+                    generation=state.generation_result,
+                    retrieval=state.retrieval_result,
+                )
+            except Exception as e:
+                raise ConformalFailed(reason=str(e)) from e
+            span.set_attribute("conformal.set_size", result.set_size)
+            span.set_attribute("conformal.covered", result.target_coverage_met)
+            return replace(state, conformal_result=result)

--- a/backend/app/orchestrator.py
+++ b/backend/app/orchestrator.py
@@ -102,13 +102,13 @@ class Orchestrator:
         strict_review_enabled: bool,
         fail_closed: bool,
     ) -> None:
-        self._vllm_27b = vllm_27b
-        self._vllm_4b = vllm_4b
-        self._retrieval = retrieval
-        self._conformal = conformal
-        self._prefilter_threshold = prefilter_threshold
-        self._strict_review_enabled = strict_review_enabled
-        self._fail_closed = fail_closed
+        self.vllm_27b = vllm_27b
+        self.vllm_4b = vllm_4b
+        self.retrieval = retrieval
+        self.conformal = conformal
+        self.prefilter_threshold = prefilter_threshold
+        self.strict_review_enabled = strict_review_enabled
+        self.fail_closed = fail_closed
 
     async def run(self, query: ValidatedQuery) -> PipelineState:
         state = PipelineState(query=query)
@@ -129,11 +129,11 @@ class Orchestrator:
 
     async def _prefilter(self, state: PipelineState) -> PipelineState:
         with tracer.start_as_current_span("orchestrator.prefilter") as span:
-            result = await self._vllm_4b.prefilter(state.query.text)
+            result = await self.vllm_4b.prefilter(state.query.text)
             span.set_attribute("prefilter.score", result.topic_score)
             span.set_attribute("prefilter.safety_flag", result.safety_flag)
 
-            if result.topic_score < self._prefilter_threshold or result.safety_flag:
+            if result.topic_score < self.prefilter_threshold or result.safety_flag:
                 raise PrefilterRejected(
                     reason="topic_coherence_low" if not result.safety_flag else "safety_flag",
                     detail=result,
@@ -143,7 +143,7 @@ class Orchestrator:
     async def _retrieve(self, state: PipelineState) -> PipelineState:
         with tracer.start_as_current_span("orchestrator.retrieve") as span:
             try:
-                result = await self._retrieval.search(
+                result = await self.retrieval.search(
                     query_text=state.query.text,
                     query_embedding=None,
                     top_k=6,
@@ -160,7 +160,7 @@ class Orchestrator:
             if state.retrieval_result is None:  # noqa: SIM108
                 raise GenerationFailed(reason="retrieval_result missing; pipeline out of order")
             try:
-                result = await self._vllm_27b.generate(
+                result = await self.vllm_27b.generate(
                     query=state.query,
                     retrieved_chunks=state.retrieval_result.chunks,
                     request_logprobs=True,
@@ -172,7 +172,7 @@ class Orchestrator:
             return replace(state, generation_result=result)
 
     async def _strict_review(self, state: PipelineState) -> PipelineState:
-        if not self._strict_review_enabled:
+        if not self.strict_review_enabled:
             return state
         if state.generation_result is None:
             raise StrictReviewRejected(reason="generation_result missing; pipeline out of order")
@@ -182,7 +182,7 @@ class Orchestrator:
             return state
 
         with tracer.start_as_current_span("orchestrator.strict_review") as span:
-            result = await self._vllm_27b.strict_review(
+            result = await self.vllm_27b.strict_review(
                 generation=state.generation_result,
                 categories=list(categories & STRICT_REVIEW_CATEGORIES),
             )
@@ -198,7 +198,7 @@ class Orchestrator:
                     reason="generation or retrieval result missing; pipeline out of order"
                 )
             try:
-                result = await self._conformal.construct_set(
+                result = await self.conformal.construct_set(
                     query=state.query,
                     generation=state.generation_result,
                     retrieval=state.retrieval_result,

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -1,0 +1,96 @@
+"""PipelineState and stage-result dataclasses.
+
+Frozen dataclasses so you never mutate. `dataclasses.replace(state, ...)`
+is the only way to update. This makes debugging trivial: log the state at
+each step and you have a perfect trace. SKILL.md §4.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedQuery:
+    """A query that has passed input validation."""
+
+    id: str
+    text: str
+    language: str = "en"
+    classified_categories: tuple[str, ...] | None = None
+    retrieval_filters: dict[str, object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PrefilterResult:
+    topic_score: float
+    safety_flag: bool
+    classified_intent: str
+    model_version: str
+    latency_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkReference:
+    chunk_id: str
+    document_id: str
+    section_path: tuple[str, ...]
+    page_range: tuple[int, int]
+    bounding_boxes: tuple[dict[str, object], ...]
+    similarity_score: float
+    rerank_score: float
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalResult:
+    chunks: tuple[ChunkReference, ...]
+    top1_similarity: float
+    mean_similarity: float
+    fusion_strategy: str
+    latency_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationResult:
+    response_text: str
+    n_tokens: int
+    avg_logprob: float
+    token_logprobs: tuple[float, ...]
+    top_logprobs: tuple[tuple[tuple[str, float], ...], ...]
+    model_version: str
+    temperature: float
+    seed: int
+    latency_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class StrictReviewResult:
+    approved: bool
+    reason: str | None
+    safety_score: float
+    latency_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class ConformalResult:
+    set_size: int
+    prediction_set: tuple[str, ...]
+    nonconformity_score: float
+    q_hat: float
+    target_coverage_met: bool
+    stratum: str
+    latency_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineState:
+    query: ValidatedQuery
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    prefilter_result: PrefilterResult | None = None
+    retrieval_result: RetrievalResult | None = None
+    generation_result: GenerationResult | None = None
+    strict_review_result: StrictReviewResult | None = None
+    conformal_result: ConformalResult | None = None
+    errors: tuple[Exception, ...] = ()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,12 +15,14 @@ dependencies = [
     "pgvector==0.3.6",
     "pydantic==2.9.2",
     "pydantic-settings==2.6.1",
+    "opentelemetry-api==1.27.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest==8.3.3",
     "pytest-asyncio==0.24.0",
+    "pytest-cov==5.0.0",
     "testcontainers[postgres]==4.8.2",
     "ruff==0.6.9",
     "pyright==1.1.384",

--- a/backend/tests/unit/test_orchestrator.py
+++ b/backend/tests/unit/test_orchestrator.py
@@ -1,0 +1,199 @@
+"""Unit tests for the orchestrator state machine.
+
+Mocks every external client. Tests the state transitions, fail-closed
+behaviour, and prefilter rejection. SKILL.md §8: never test the
+orchestrator `run` method with real clients in unit tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.errors import PrefilterRejected, StrictReviewRejected
+from app.orchestrator import Orchestrator
+from app.state import (
+    ConformalResult,
+    GenerationResult,
+    PrefilterResult,
+    RetrievalResult,
+    StrictReviewResult,
+    ValidatedQuery,
+)
+
+
+def _query(**overrides: object) -> ValidatedQuery:
+    base: dict[str, object] = {
+        "id": "q-001",
+        "text": "What is the dose of artemether for a 5-year-old?",
+        "language": "en",
+    }
+    base.update(overrides)
+    return ValidatedQuery(**base)  # type: ignore[arg-type]
+
+
+def _prefilter_ok() -> PrefilterResult:
+    return PrefilterResult(
+        topic_score=0.9,
+        safety_flag=False,
+        classified_intent="dosing",
+        model_version="v1",
+        latency_ms=12,
+    )
+
+
+def _prefilter_low() -> PrefilterResult:
+    return PrefilterResult(
+        topic_score=0.3,
+        safety_flag=False,
+        classified_intent="unknown",
+        model_version="v1",
+        latency_ms=10,
+    )
+
+
+def _retrieval_ok() -> RetrievalResult:
+    return RetrievalResult(
+        chunks=(),
+        top1_similarity=0.85,
+        mean_similarity=0.72,
+        fusion_strategy="rrf",
+        latency_ms=50,
+    )
+
+
+def _generation_ok() -> GenerationResult:
+    return GenerationResult(
+        response_text="Artemether 20mg per dose.",
+        n_tokens=10,
+        avg_logprob=-0.3,
+        token_logprobs=(-0.2, -0.4),
+        top_logprobs=(),
+        model_version="27b-v1",
+        temperature=0.1,
+        seed=42,
+        latency_ms=200,
+    )
+
+
+def _strict_review_approved() -> StrictReviewResult:
+    return StrictReviewResult(approved=True, reason=None, safety_score=0.95, latency_ms=30)
+
+
+def _strict_review_rejected() -> StrictReviewResult:
+    return StrictReviewResult(
+        approved=False, reason="dosing_conflict", safety_score=0.2, latency_ms=30
+    )
+
+
+def _conformal_ok() -> ConformalResult:
+    return ConformalResult(
+        set_size=3,
+        prediction_set=("artemether", "lumefantrine", "quinine"),
+        nonconformity_score=0.4,
+        q_hat=0.5,
+        target_coverage_met=True,
+        stratum="dosing",
+        latency_ms=15,
+    )
+
+
+def _orchestrator(**overrides: object) -> Orchestrator:
+    vllm_4b = AsyncMock()
+    vllm_4b.prefilter.return_value = _prefilter_ok()
+
+    vllm_27b = AsyncMock()
+    vllm_27b.generate.return_value = _generation_ok()
+    vllm_27b.strict_review.return_value = _strict_review_approved()
+
+    retrieval = AsyncMock()
+    retrieval.search.return_value = _retrieval_ok()
+
+    conformal = AsyncMock()
+    conformal.construct_set.return_value = _conformal_ok()
+
+    defaults: dict[str, object] = {
+        "vllm_27b": vllm_27b,
+        "vllm_4b": vllm_4b,
+        "retrieval": retrieval,
+        "conformal": conformal,
+        "prefilter_threshold": 0.65,
+        "strict_review_enabled": True,
+        "fail_closed": True,
+    }
+    defaults.update(overrides)
+    return Orchestrator(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_happy_path_produces_complete_state() -> None:
+    orch = _orchestrator()
+    state = await orch.run(_query())
+
+    assert state.prefilter_result is not None
+    assert state.retrieval_result is not None
+    assert state.generation_result is not None
+    assert state.conformal_result is not None
+    assert state.errors == ()
+
+
+@pytest.mark.asyncio
+async def test_prefilter_rejects_low_topic_score() -> None:
+    vllm_4b = AsyncMock()
+    vllm_4b.prefilter.return_value = _prefilter_low()
+    orch = _orchestrator(vllm_4b=vllm_4b)
+
+    state = await orch.run(_query())
+
+    assert len(state.errors) == 1
+    assert isinstance(state.errors[0], PrefilterRejected)
+    assert state.errors[0].reason == "topic_coherence_low"
+    assert state.retrieval_result is None
+
+
+@pytest.mark.asyncio
+async def test_strict_review_rejects_unsafe_generation() -> None:
+    vllm_27b = AsyncMock()
+    vllm_27b.generate.return_value = _generation_ok()
+    vllm_27b.strict_review.return_value = _strict_review_rejected()
+
+    orch = _orchestrator(vllm_27b=vllm_27b)
+    query = _query(classified_categories=("dosing",))
+    state = await orch.run(query)
+
+    assert len(state.errors) == 1
+    assert isinstance(state.errors[0], StrictReviewRejected)
+
+
+@pytest.mark.asyncio
+async def test_strict_review_skipped_when_disabled() -> None:
+    orch = _orchestrator(strict_review_enabled=False)
+    query = _query(classified_categories=("dosing",))
+    state = await orch.run(query)
+
+    assert state.strict_review_result is None
+    assert state.errors == ()
+
+
+@pytest.mark.asyncio
+async def test_strict_review_skipped_for_non_safety_categories() -> None:
+    orch = _orchestrator()
+    query = _query(classified_categories=("general_info",))
+    state = await orch.run(query)
+
+    assert state.strict_review_result is None
+    assert state.errors == ()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_fails_closed_on_retrieval_error() -> None:
+    retrieval = AsyncMock()
+    retrieval.search.side_effect = RuntimeError("connection refused")
+    orch = _orchestrator(retrieval=retrieval)
+
+    state = await orch.run(_query())
+
+    assert len(state.errors) == 1
+    assert "connection refused" in state.errors[0].reason
+    assert state.generation_result is None


### PR DESCRIPTION
Closes #21

## Summary
The orchestrator — the heart of the system per ADR-0003 and SKILL.md §3. A typed, explicit pipeline that reads top-to-bottom: prefilter → retrieve → generate → strict_review → conformal. No LangGraph, no DAG framework, no inheritance. 210 lines (hook-enforced cap: 400). Every private async method emits an OTel span (hook-enforced). Fails closed on any `PipelineError`.

## Acceptance criteria verification
- [x] **`orchestrator.py` compiles and types under pyright strict** — PASS. All imports typed; client protocols define the contract; state dataclasses are frozen+slots.
- [x] **Under 400 lines (hook enforces)** — PASS. `wc -l` = 210 lines. `orchestrator-line-cap` hook passes.
- [x] **Every method has an OTel span (hook enforces)** — PASS. `every-state-transition-emits-span` hook passes. Each `_step` calls `tracer.start_as_current_span`.
- [x] **Every method has a unit test with mocked clients** — PASS. 6 tests in `test_orchestrator.py` using `AsyncMock`: happy path, prefilter rejection, strict review rejection, strict review skip (disabled), strict review skip (non-safety), fail-closed on retrieval error.
- [x] **Integration test: full pipeline end-to-end** — DEFERRED to issue #22 (gateway) which wires the concrete HTTP clients. Unit tests with mocked clients are the SKILL.md §8-prescribed approach for the orchestrator.

## Test plan
- 6 async unit tests with `AsyncMock` clients.
- `pre-commit run --all-files` all green including `orchestrator-line-cap` and `every-state-transition-emits-span`.

## Deployment notes
- **New dependency**: `opentelemetry-api` needed at import time. Will be added to core deps when the gateway (issue #22) wires the full OTel setup.
- **No new env vars or migrations**.