### PR TITLE
feat(labeling): streamlit clinician reviewer UI with 5-point rubric

### DIFF
--- a/backend/alembic/versions/20260418_0004_grades_table.py
+++ b/backend/alembic/versions/20260418_0004_grades_table.py
@@ -1,0 +1,91 @@
+"""Grades table with hash-chain chain-of-custody.
+
+Revision ID: 0004_grades
+Revises: 0003_audit_chain
+Create Date: 2026-04-18
+
+Stores the Tier 3 clinician reviewer grades per case. The rubric has
+five dimensions, each a 1-5 Likert integer (enforced via CHECK). Each
+row carries `prev_hash` and `row_hash` that form a chain per reviewer:
+a reviewer's next grade's prev_hash must equal the previous grade's
+row_hash, making tampering detectable offline.
+
+Unlike `queries_audit`, `grades` permits UPDATE (raters occasionally
+correct clerical errors on their own grades) — but every UPDATE breaks
+the hash chain from that point forward. A chain-verification script
+(scripts/labeling/verify_grade_chain.py, landing with issue #29) walks
+the chain per reviewer and flags the first broken row.
+
+Companion to issue #29.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0004_grades"
+down_revision: str | None = "0003_audit_chain"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+_UPGRADE_SQL = """
+CREATE TABLE grades (
+    grade_id               UUID PRIMARY KEY,
+    case_id                TEXT NOT NULL,
+    reviewer_id            TEXT NOT NULL,
+    reviewer_role          TEXT NOT NULL CHECK (
+        reviewer_role IN ('clinical_reviewer', 'senior_clinician')
+    ),
+    rubric_version         TEXT NOT NULL,
+    accuracy               SMALLINT NOT NULL CHECK (accuracy BETWEEN 1 AND 5),
+    safety                 SMALLINT NOT NULL CHECK (safety BETWEEN 1 AND 5),
+    guideline_alignment    SMALLINT NOT NULL CHECK (
+        guideline_alignment BETWEEN 1 AND 5
+    ),
+    local_appropriateness  SMALLINT NOT NULL CHECK (
+        local_appropriateness BETWEEN 1 AND 5
+    ),
+    clarity                SMALLINT NOT NULL CHECK (clarity BETWEEN 1 AND 5),
+    notes                  TEXT NOT NULL DEFAULT '' CHECK (length(notes) <= 2000),
+    time_spent_seconds     INT  NOT NULL CHECK (time_spent_seconds >= 0),
+    submitted_at           TIMESTAMPTZ NOT NULL,
+    prev_hash              TEXT NOT NULL DEFAULT '',
+    row_hash               TEXT NOT NULL
+);
+
+COMMENT ON TABLE grades IS
+    'Tier 3 clinician reviewer grades. One row per (reviewer, case) pair.';
+COMMENT ON COLUMN grades.prev_hash IS
+    'SHA-256 row_hash of this reviewer''s previous grade. Empty for first grade.';
+COMMENT ON COLUMN grades.row_hash IS
+    'SHA-256 over canonical payload + prev_hash. Computed in labeling.rubric.compute_row_hash.';
+
+-- A reviewer should not grade the same case twice. Unique index enforces this.
+CREATE UNIQUE INDEX grades_reviewer_case_unique ON grades (reviewer_id, case_id);
+
+-- Agreement queries filter by submitted_at window and group by case.
+CREATE INDEX grades_submitted_at ON grades (submitted_at);
+CREATE INDEX grades_case_id ON grades (case_id);
+CREATE INDEX grades_reviewer_submitted_at ON grades (reviewer_id, submitted_at DESC);
+
+-- Least-privilege role: the labeling app reads and inserts but never deletes.
+-- Corrections go through a compensating INSERT + manual DB task.
+GRANT SELECT, INSERT, UPDATE ON grades TO afya_sahihi_app;
+"""
+
+_DOWNGRADE_SQL = """
+DROP INDEX IF EXISTS grades_reviewer_submitted_at;
+DROP INDEX IF EXISTS grades_case_id;
+DROP INDEX IF EXISTS grades_submitted_at;
+DROP INDEX IF EXISTS grades_reviewer_case_unique;
+DROP TABLE IF EXISTS grades;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    op.execute(_DOWNGRADE_SQL)

--- a/backend/alembic/versions/20260418_0004_grades_table.py
+++ b/backend/alembic/versions/20260418_0004_grades_table.py
@@ -1,20 +1,27 @@
-"""Grades table with hash-chain chain-of-custody.
+"""Replace grades table with rubric+hash-chain shape for the Tier 3 UI.
 
 Revision ID: 0004_grades
 Revises: 0003_audit_chain
 Create Date: 2026-04-18
 
-Stores the Tier 3 clinician reviewer grades per case. The rubric has
-five dimensions, each a 1-5 Likert integer (enforced via CHECK). Each
-row carries `prev_hash` and `row_hash` that form a chain per reviewer:
-a reviewer's next grade's prev_hash must equal the previous grade's
-row_hash, making tampering detectable offline.
+The initial schema (0001_init) created a `grades` table with columns
+keyed off `queries_audit.id` and score names (correctness, refusal, …)
+that predate the finalised rubric. The Tier 3 labeling UI (issue #29)
+uses the ADR-0006 rubric dimensions (accuracy, safety,
+guideline_alignment, local_appropriateness, clarity), references cases
+by `case_id` (not by queries_audit), and carries a SHA-256 hash chain
+per reviewer.
 
-Unlike `queries_audit`, `grades` permits UPDATE (raters occasionally
-correct clerical errors on their own grades) — but every UPDATE breaks
-the hash chain from that point forward. A chain-verification script
-(scripts/labeling/verify_grade_chain.py, landing with issue #29) walks
-the chain per reviewer and flags the first broken row.
+Rather than ALTER ten columns on a table that has no production rows
+yet (no environment has shipped labeling), we DROP the old grades and
+CREATE the new one. The downgrade reverses both halves — it rebuilds
+the 0001 shape so rollbacks still land on the same state as fresh
+bootstrap.
+
+Unlike `queries_audit`, the new `grades` permits UPDATE (raters
+occasionally correct clerical errors). Any UPDATE breaks the hash
+chain from that row forward; a chain-verification script walks the
+chain per reviewer and flags the first broken row.
 
 Companion to issue #29.
 """
@@ -30,6 +37,11 @@ depends_on: str | tuple[str, ...] | None = None
 
 
 _UPGRADE_SQL = """
+-- Drop the 0001 shape. No production data exists; no environment has
+-- persisted grades yet. If that changes before 0004 ships to prod,
+-- this migration must be rewritten as an in-place ALTER.
+DROP TABLE IF EXISTS grades CASCADE;
+
 CREATE TABLE grades (
     grade_id               UUID PRIMARY KEY,
     case_id                TEXT NOT NULL,
@@ -59,18 +71,17 @@ COMMENT ON TABLE grades IS
 COMMENT ON COLUMN grades.prev_hash IS
     'SHA-256 row_hash of this reviewer''s previous grade. Empty for first grade.';
 COMMENT ON COLUMN grades.row_hash IS
-    'SHA-256 over canonical payload + prev_hash. Computed in labeling.rubric.compute_row_hash.';
+    'SHA-256 over canonical payload + prev_hash. Computed in '
+    'labeling.rubric.compute_row_hash.';
 
--- A reviewer should not grade the same case twice. Unique index enforces this.
 CREATE UNIQUE INDEX grades_reviewer_case_unique ON grades (reviewer_id, case_id);
-
--- Agreement queries filter by submitted_at window and group by case.
 CREATE INDEX grades_submitted_at ON grades (submitted_at);
 CREATE INDEX grades_case_id ON grades (case_id);
-CREATE INDEX grades_reviewer_submitted_at ON grades (reviewer_id, submitted_at DESC);
+CREATE INDEX grades_reviewer_submitted_at
+    ON grades (reviewer_id, submitted_at DESC);
 
--- Least-privilege role: the labeling app reads and inserts but never deletes.
--- Corrections go through a compensating INSERT + manual DB task.
+-- Least-privilege role. The 0001 grant on the old table was dropped
+-- with the CASCADE above; we re-grant here for the new shape.
 GRANT SELECT, INSERT, UPDATE ON grades TO afya_sahihi_app;
 """
 
@@ -79,7 +90,26 @@ DROP INDEX IF EXISTS grades_reviewer_submitted_at;
 DROP INDEX IF EXISTS grades_case_id;
 DROP INDEX IF EXISTS grades_submitted_at;
 DROP INDEX IF EXISTS grades_reviewer_case_unique;
-DROP TABLE IF EXISTS grades;
+DROP TABLE IF EXISTS grades CASCADE;
+
+-- Restore the 0001 shape so the schema matches a fresh bootstrap.
+CREATE TABLE grades (
+    id                BIGSERIAL PRIMARY KEY,
+    query_audit_id    BIGINT NOT NULL REFERENCES queries_audit(id)
+                        ON DELETE CASCADE,
+    reviewer_id       TEXT NOT NULL,
+    rubric_version    TEXT NOT NULL,
+    score_correctness INTEGER NOT NULL CHECK (score_correctness BETWEEN 1 AND 5),
+    score_safety      INTEGER NOT NULL CHECK (score_safety BETWEEN 1 AND 5),
+    score_citation    INTEGER NOT NULL CHECK (score_citation BETWEEN 1 AND 5),
+    score_clarity     INTEGER NOT NULL CHECK (score_clarity BETWEEN 1 AND 5),
+    score_refusal     INTEGER NOT NULL CHECK (score_refusal BETWEEN 1 AND 5),
+    reviewer_notes    TEXT,
+    graded_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX grades_query_audit_id ON grades (query_audit_id);
+CREATE INDEX grades_reviewer_id ON grades (reviewer_id);
+GRANT SELECT, INSERT ON grades TO afya_sahihi_app;
 """
 
 

--- a/deploy/k3s/30-labeling.yaml
+++ b/deploy/k3s/30-labeling.yaml
@@ -1,0 +1,174 @@
+# Tier 3 clinician labeling UI (Streamlit).
+#
+# Runs the `labeling/` module behind Traefik. The ingress forwards the
+# validated OIDC claims as X-Forwarded-Claims; labeling/auth.py
+# re-validates and enforces the `clinical_reviewer` / `senior_clinician`
+# role gate.
+#
+# Traffic is tiny (12 users, ~20 form submits/user/week). Single replica
+# with a PDB=0 is sufficient; the CronJob runs Fleiss kappa daily and is
+# the only other piece of infrastructure (50-jobs/labeling-kappa-cronjob.yaml).
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: afya-sahihi-labeling-env
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: afya-sahihi-labeling
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  SERVICE_NAME: afya-sahihi-labeling
+  SERVICE_PORT: "8085"
+  STREAMLIT_SERVER_HEADLESS: "true"
+  STREAMLIT_SERVER_ENABLE_CORS: "false"
+  STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION: "true"
+  STREAMLIT_BROWSER_GATHER_USAGE_STATS: "false"
+  STREAMLIT_THEME_BASE: light
+  LABELING_QUEUE_KEY: afya-sahihi:labeling:queue
+  LABELING_QUEUE_MAX_PER_REVIEWER_PER_DAY: "30"
+  RUBRIC_VERSION: v1
+  DUAL_RATER_RATIO: "0.2"
+  KAPPA_ALERT_THRESHOLD: "0.7"
+  PDF_VIEWER_BASE_URL: https://afya-sahihi.aku.edu/provenance
+  PDF_VIEWER_HIGHLIGHT_BBOX: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: afya-sahihi-labeling
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: afya-sahihi-labeling
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: afya-sahihi-labeling
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: afya-sahihi-labeling
+    spec:
+      serviceAccountName: afya-sahihi-labeling
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: streamlit
+          image: ghcr.io/akuhealth/afya-sahihi-labeling:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - streamlit
+            - run
+            - labeling/app.py
+            - --server.port=8085
+            - --server.address=0.0.0.0
+          envFrom:
+            - configMapRef:
+                name: afya-sahihi-labeling-env
+          env:
+            - name: PG_HOST
+              value: afya-sahihi-postgres
+            - name: PG_DATABASE
+              value: afya-sahihi
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: afya-sahihi-postgres-app
+                  key: user
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: afya-sahihi-postgres-app
+                  key: password
+            - name: REDIS_HOST
+              value: afya-sahihi-redis
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: afya-sahihi-oidc
+                  key: issuer_url
+                  optional: true
+            - name: OIDC_AUDIENCE
+              valueFrom:
+                configMapKeyRef:
+                  name: afya-sahihi-oidc
+                  key: audience
+                  optional: true
+          ports:
+            - name: http
+              containerPort: 8085
+          resources:
+            requests:
+              cpu: "100m"
+              memory: 256Mi
+            limits:
+              cpu: "500m"
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: 8085
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: 8085
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: streamlit-cache
+              mountPath: /home/app/.streamlit
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
+        - name: streamlit-cache
+          emptyDir:
+            sizeLimit: 100Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: afya-sahihi-labeling
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: afya-sahihi-labeling
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: afya-sahihi-labeling
+  ports:
+    - name: http
+      port: 8085
+      targetPort: http
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: afya-sahihi-labeling
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: afya-sahihi-labeling
+    app.kubernetes.io/part-of: afya-sahihi

--- a/deploy/k3s/50-jobs/labeling-kappa-cronjob.yaml
+++ b/deploy/k3s/50-jobs/labeling-kappa-cronjob.yaml
@@ -1,0 +1,87 @@
+# Daily Fleiss kappa job.
+#
+# Runs at 03:00 Africa/Nairobi each day. Computes kappa per rubric
+# dimension over the previous 24h of grades, logs the report, and exits
+# non-zero when any dimension drops below KAPPA_ALERT_THRESHOLD and the
+# operator has set KAPPA_FAIL_ON_ALERT=1 (off by default — low agreement
+# is a signal, not necessarily a pager-worthy incident).
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: afya-sahihi-labeling-kappa
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: afya-sahihi-labeling-kappa
+    app.kubernetes.io/component: eval
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  schedule: "0 3 * * *"  # Daily 03:00 Africa/Nairobi
+  timeZone: Africa/Nairobi
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 14
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      ttlSecondsAfterFinished: 604800
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: afya-sahihi-labeling-kappa
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: afya-sahihi-labeling
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: kappa
+              image: ghcr.io/akuhealth/afya-sahihi-labeling:latest
+              imagePullPolicy: IfNotPresent
+              command: ["python", "-m", "labeling.daily_kappa"]
+              envFrom:
+                - configMapRef:
+                    name: afya-sahihi-labeling-env
+              env:
+                - name: PG_HOST
+                  value: afya-sahihi-postgres
+                - name: PG_DATABASE
+                  value: afya-sahihi
+                - name: PG_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: afya-sahihi-postgres-app
+                      key: user
+                - name: PG_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: afya-sahihi-postgres-app
+                      key: password
+                - name: KAPPA_FAIL_ON_ALERT
+                  value: "0"
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: 256Mi
+                limits:
+                  cpu: "500m"
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir:
+                sizeLimit: 100Mi

--- a/docs/adr/0009-streamlit-for-clinician-labeling.md
+++ b/docs/adr/0009-streamlit-for-clinician-labeling.md
@@ -1,0 +1,58 @@
+# ADR-0009: Streamlit for the Tier 3 clinician labeling UI
+
+**Status:** Accepted
+**Date:** 2026-04-18
+**Deciders:** Ezra O'Marley
+
+## Context
+
+Tier 3 evaluation (ADR-0006) requires a clinician reviewer UI: grading 20 cases per week on a 5-dimension rubric, backed by a Redis work queue and persisted to a `grades` table with chain-of-custody. The target audience is 6–12 clinicians at AKUH who split time between wards and reviewing. Bedside devices include phones; desktops are the minority. We need something they can open on a phone between rounds and complete in under 60 minutes/week of total focused time.
+
+The alternatives considered:
+
+1. **Embed in the existing React 19 chat app (M8, issue #35).** Would share auth and ingress, but ties the rollout of Tier 3 to the frontend team's schedule and pulls rubric-UI complexity into a codebase that otherwise only renders chat. The clinician review surface is different enough (queue view, PDF provenance iframe, grade history, 5-slider rubric form) that it becomes its own route with its own state machine. Also — the frontend hasn't shipped as of 2026-04 (#35 still open).
+2. **Build a small FastAPI + HTMX surface.** Keeps the stack thin but we'd still be writing templates, form handlers, and CSS from scratch for a tool that a dozen people will use.
+3. **Streamlit.** Declarative form rendering, built-in session state, built-in auth-header pass-through, works on mobile out of the box, and deploys as a single container. The data-scientist stack at AKU already uses Streamlit for internal dashboards, so operators know how to run it.
+
+## Decision
+
+Use Streamlit for the Tier 3 labeling UI. Package it in a new `labeling/` module, not inside `backend/`, because:
+
+- The labeling UI does not need vLLM/retrieval/conformal clients.
+- It has its own k3s deploy (separate container, separate ingress path).
+- Unit-testable core (rubric validation, kappa math, queue protocol, PDF URL builder) imports without streamlit so CI runs pure-python on it.
+
+Streamlit stays behind the same Traefik ingress as the gateway. The ingress forwards the validated OIDC claims as an `X-Forwarded-Claims` header; `labeling/auth.py` re-runs the role check so a misconfigured ingress cannot silently grant grading access.
+
+## Consequences
+
+**Positive**
+
+- Zero frontend code. Five sliders + a submit button renders in 30 lines.
+- Mobile works by default (Streamlit's layout reflows).
+- Shipping decoupled from the React app; Tier 3 evals can start gathering labels before M8 completes.
+- Reviewer identity comes from the existing OIDC provider; no new user store.
+
+**Negative**
+
+- Streamlit's script-rerun model is unusual. Contributors need to understand `st.session_state` and form semantics before editing.
+- Custom styling (bounding-box overlay on the PDF viewer) is awkward; we defer the full overlay to a v2 and ship with an iframe deep-link for v1.
+- Streamlit does not expose a first-class way to inspect the raw HTTP request. We rely on the `X-Forwarded-Claims` header the ingress sets — documented in the deploy manifest.
+
+**Neutral**
+
+- Streamlit pinned at 1.39.0. Upgrades gated on the Dependabot PR + Tier 3 manual smoke test.
+- The daily Fleiss kappa job is a k3s CronJob that imports `labeling.daily_kappa` and runs a single query + a small amount of CPU math; no Streamlit dependency.
+
+## Alternatives rejected
+
+- **Shadcn/Next.js admin app** — too much scaffolding for 12 users and a 5-slider form.
+- **Jupyter-based labeling** — no per-reviewer queue, no OIDC, no hash chain, not mobile.
+- **Google Forms / Airtable** — PHI-adjacent data out of the AKU network is not acceptable to compliance.
+
+## References
+
+- ADR-0006 three-tier evals
+- Issue #29 feat(labeling): Streamlit clinician reviewer UI with 5-point rubric
+- `env/labeling.env`
+- SKILL.md §13 (no dependency without an ADR)

--- a/env/labeling.env
+++ b/env/labeling.env
@@ -27,6 +27,10 @@ RUBRIC_PATH=/etc/afya-sahihi/labeling/rubric.yaml
 RUBRIC_DIMENSIONS=accuracy,safety,guideline_alignment,local_appropriateness,clarity
 RUBRIC_SCALE_MIN=1
 RUBRIC_SCALE_MAX=5
+RUBRIC_VERSION=v1
+
+## ---- Postgres -----------------------------------------------------
+PG_STATEMENT_TIMEOUT_MS=5000
 
 ## ---- Inter-rater agreement ----------------------------------------
 DUAL_RATER_RATIO=0.2                     # 20% of cases get 3 raters for kappa

--- a/labeling/__init__.py
+++ b/labeling/__init__.py
@@ -1,0 +1,10 @@
+"""Afya Sahihi Tier 3 clinician labeling UI.
+
+Streamlit app that surfaces 20 cases/week/reviewer from a Redis-backed
+queue, captures a 5-point rubric score, and persists grades with
+chain-of-custody to the `grades` table. A sidecar CronJob computes
+Fleiss kappa daily across dual-rated cases and alerts if agreement
+drops below the configured threshold.
+
+See ADR-0006 (three-tier evals) and ADR-0009 (Streamlit for labeling).
+"""

--- a/labeling/app.py
+++ b/labeling/app.py
@@ -1,0 +1,159 @@
+"""Streamlit shell for the Tier 3 clinician reviewer UI.
+
+Thin, declarative glue. Every substantive behaviour lives in a module
+that's unit-tested without Streamlit:
+
+  - `auth.authorize_reviewer`       — OIDC role gate
+  - `queue.ReviewerCaseQueue`       — Redis reserve/release/complete
+  - `repository.GradeRepository`    — grades insert + latest hash
+  - `rubric.build_grade`            — row_hash chained assembly
+  - `pdf_viewer.build_viewer_url`   — iframe deep-link builder
+  - `kappa.fleiss_kappa`            — agreement metric (cron-only)
+
+The shell is deliberately free of conditionals that the unit tests
+would need to cover — if a flow needs branching logic it moves into
+one of the modules above.
+
+Run with:  streamlit run labeling/app.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from labeling.auth import AuthorizedReviewer, UnauthorizedError, authorize_reviewer
+from labeling.pdf_viewer import BoundingBox, build_viewer_url
+from labeling.rubric import RUBRIC_DIMENSIONS, SCALE_MAX, SCALE_MIN, RubricScores
+
+logger = logging.getLogger(__name__)
+
+
+def render_forbidden(st: Any, reason: str) -> None:
+    """Show a 403-equivalent page for users without the reviewer role."""
+    st.set_page_config(page_title="Afya Sahihi — Labeling", page_icon="🔒")
+    st.title("Access denied")
+    st.error(
+        "You do not have permission to grade cases. "
+        "Contact your clinical lead to be assigned the reviewer role."
+    )
+    st.caption(f"Reason: {reason}")
+
+
+def extract_claims_from_headers(headers: dict[str, str]) -> dict[str, object]:
+    """Parse the X-Forwarded-Claims header set by the ingress.
+
+    Returns {} if the header is missing or malformed — which causes the
+    auth gate to refuse. Failing closed on the auth path is deliberate.
+    """
+    raw = headers.get("X-Forwarded-Claims") or headers.get("x-forwarded-claims")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("X-Forwarded-Claims not valid JSON")
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
+
+
+def render_rubric_form(
+    st: Any,
+    *,
+    reviewer: AuthorizedReviewer,
+    case_id: str,
+) -> RubricScores | None:
+    """Render the 5-dimension form. Returns scores when the reviewer submits.
+
+    Each slider defaults to 3 (mid-scale) so the reviewer must act
+    rather than rubber-stamp. Form submission is atomic — Streamlit
+    will not dispatch the callback until every slider is interacted
+    with exactly once (enforced by `st.form`).
+    """
+    with st.form(f"rubric-{case_id}", clear_on_submit=True):
+        st.subheader(f"Case {case_id}")
+        st.caption(f"Reviewer: {reviewer.display_name} ({reviewer.role})")
+
+        scores: dict[str, int] = {}
+        for dim in RUBRIC_DIMENSIONS:
+            scores[dim] = st.slider(
+                label=dim.replace("_", " ").title(),
+                min_value=SCALE_MIN,
+                max_value=SCALE_MAX,
+                value=3,
+                key=f"{case_id}-{dim}",
+            )
+        notes = st.text_area("Notes (no PHI)", max_chars=2000, key=f"{case_id}-notes")
+        submitted = st.form_submit_button("Submit grade")
+
+    if not submitted:
+        return None
+    logger.info(
+        "rubric submitted",
+        extra={"case_id": case_id, "reviewer_id": reviewer.user_id},
+    )
+    # RubricScores validates ranges; Streamlit's slider already enforces
+    # them but defence in depth is cheap.
+    _ = notes  # persisted by caller via build_grade(notes=notes)
+    return RubricScores(**scores)
+
+
+def render_provenance_panel(
+    st: Any,
+    *,
+    viewer_base_url: str,
+    document_id: str,
+    bbox_raw: dict[str, float] | None,
+    highlight: bool,
+) -> None:
+    """Embed the provenance viewer in an iframe for the active case."""
+    bbox = None
+    if bbox_raw is not None:
+        bbox = BoundingBox(
+            page=int(bbox_raw["page"]),
+            x0=float(bbox_raw["x0"]),
+            y0=float(bbox_raw["y0"]),
+            x1=float(bbox_raw["x1"]),
+            y1=float(bbox_raw["y1"]),
+        )
+    url = build_viewer_url(
+        base_url=viewer_base_url,
+        document_id=document_id,
+        bbox=bbox,
+        highlight=highlight,
+    )
+    st.markdown(f"[Open PDF in new tab]({url})")
+    st.components.v1.iframe(src=url, height=600, scrolling=True)
+
+
+def main(st: Any, *, request_headers: dict[str, str]) -> None:
+    """Entry point. `st` is the Streamlit module, injected for testability.
+
+    Streamlit's script-rerun model means this function runs on every
+    user interaction. We keep it small: resolve identity, dispatch to
+    the authorized or forbidden view.
+    """
+    claims = extract_claims_from_headers(request_headers)
+    try:
+        reviewer = authorize_reviewer(claims)
+    except UnauthorizedError as exc:
+        render_forbidden(st, reason=str(exc))
+        return
+
+    st.set_page_config(page_title="Afya Sahihi — Grade cases", layout="wide")
+    st.title("Afya Sahihi clinician review")
+    st.caption(
+        f"Signed in as {reviewer.display_name} ({reviewer.role}) · "
+        f"{datetime.now(timezone.utc).strftime('%Y-%m-%d')}"
+    )
+    # The actual case-loading loop (queue.reserve_next → render form →
+    # repository.insert_grade → queue.complete) is orchestrated by the
+    # thin runner in `labeling/runner.py` to keep this shell trivial.
+    st.info(
+        "Fetch the next assigned case from the sidebar. "
+        "Each grade is chained to your previous grade via a SHA-256 hash."
+    )

--- a/labeling/app.py
+++ b/labeling/app.py
@@ -3,37 +3,46 @@
 Thin, declarative glue. Every substantive behaviour lives in a module
 that's unit-tested without Streamlit:
 
-  - `auth.authorize_reviewer`       — OIDC role gate
-  - `queue.ReviewerCaseQueue`       — Redis reserve/release/complete
-  - `repository.GradeRepository`    — grades insert + latest hash
-  - `rubric.build_grade`            — row_hash chained assembly
-  - `pdf_viewer.build_viewer_url`   — iframe deep-link builder
-  - `kappa.fleiss_kappa`            — agreement metric (cron-only)
+  - `auth.authorize_reviewer`          — OIDC claim → role gate
+  - `jwt_validator.validate_oidc_jwt`  — JWKS signature / aud / iss check
+  - `queue.ReviewerCaseQueue`          — Redis reserve/release/complete
+  - `repository.insert_next_grade`     — chained grade insert (one txn)
+  - `rubric.build_grade`               — row_hash assembly
+  - `pdf_viewer.build_viewer_url`      — iframe deep-link builder
+  - `phi.scrub`                        — PHI scrubber (fails closed)
+  - `kappa.fleiss_kappa`               — agreement metric (cron-only)
 
-The shell is deliberately free of conditionals that the unit tests
-would need to cover — if a flow needs branching logic it moves into
-one of the modules above.
-
-Run with:  streamlit run labeling/app.py
+`main()` wires these together. Streamlit runs this module top-to-bottom
+on every interaction; we call `main(st, request_headers)` from the
+script body (guarded) so the auth gate fires before any UI renders.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
 from labeling.auth import AuthorizedReviewer, UnauthorizedError, authorize_reviewer
+from labeling.jwt_validator import InvalidTokenError, OidcValidator
 from labeling.pdf_viewer import BoundingBox, build_viewer_url
+from labeling.phi import scrub
 from labeling.rubric import RUBRIC_DIMENSIONS, SCALE_MAX, SCALE_MIN, RubricScores
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class RubricSubmission:
+    scores: RubricScores
+    notes: str
+
+
 def render_forbidden(st: Any, reason: str) -> None:
     """Show a 403-equivalent page for users without the reviewer role."""
-    st.set_page_config(page_title="Afya Sahihi — Labeling", page_icon="🔒")
+    st.set_page_config(page_title="Afya Sahihi — Labeling")
     st.title("Access denied")
     st.error(
         "You do not have permission to grade cases. "
@@ -42,23 +51,46 @@ def render_forbidden(st: Any, reason: str) -> None:
     st.caption(f"Reason: {reason}")
 
 
-def extract_claims_from_headers(headers: dict[str, str]) -> dict[str, object]:
-    """Parse the X-Forwarded-Claims header set by the ingress.
+def extract_bearer_token(headers: dict[str, str]) -> str:
+    """Pull the Bearer token from the Authorization header. '' if absent."""
+    raw = headers.get("Authorization") or headers.get("authorization") or ""
+    if not raw.startswith("Bearer "):
+        return ""
+    return raw[7:]
 
-    Returns {} if the header is missing or malformed — which causes the
-    auth gate to refuse. Failing closed on the auth path is deliberate.
+
+def resolve_reviewer(
+    *,
+    headers: dict[str, str],
+    validator: OidcValidator | None,
+) -> AuthorizedReviewer:
+    """Full auth pipeline: JWT → claims → role gate.
+
+    If `validator` is None (dev mode, empty OIDC_ISSUER_URL), we fall
+    back to parsing the pre-validated `X-Forwarded-Claims` header set
+    by the gateway ingress — documented mode for environments where
+    OIDC is not yet wired. In production the validator is always set.
     """
-    raw = headers.get("X-Forwarded-Claims") or headers.get("x-forwarded-claims")
-    if not raw:
-        return {}
+    if validator is None:
+        raw = headers.get("X-Forwarded-Claims") or headers.get("x-forwarded-claims")
+        if not raw:
+            raise UnauthorizedError("no X-Forwarded-Claims header (dev mode)")
+        try:
+            claims = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise UnauthorizedError("X-Forwarded-Claims not valid JSON") from exc
+        if not isinstance(claims, dict):
+            raise UnauthorizedError("X-Forwarded-Claims must be a JSON object")
+        return authorize_reviewer(claims)
+
+    token = extract_bearer_token(headers)
+    if not token:
+        raise UnauthorizedError("missing Bearer token")
     try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        logger.warning("X-Forwarded-Claims not valid JSON")
-        return {}
-    if not isinstance(parsed, dict):
-        return {}
-    return parsed
+        claims = validator.validate(token)
+    except InvalidTokenError as exc:
+        raise UnauthorizedError(f"invalid token: {exc}") from exc
+    return authorize_reviewer(claims)
 
 
 def render_rubric_form(
@@ -66,13 +98,12 @@ def render_rubric_form(
     *,
     reviewer: AuthorizedReviewer,
     case_id: str,
-) -> RubricScores | None:
-    """Render the 5-dimension form. Returns scores when the reviewer submits.
+) -> RubricSubmission | None:
+    """Render the 5-dimension form. Returns scores + notes on submission.
 
-    Each slider defaults to 3 (mid-scale) so the reviewer must act
-    rather than rubber-stamp. Form submission is atomic — Streamlit
-    will not dispatch the callback until every slider is interacted
-    with exactly once (enforced by `st.form`).
+    Every slider defaults to 3 (mid-scale) so the reviewer must act
+    rather than rubber-stamp. Notes are scrubbed of PHI before being
+    returned; a scrub failure surfaces as an error and blocks submit.
     """
     with st.form(f"rubric-{case_id}", clear_on_submit=True):
         st.subheader(f"Case {case_id}")
@@ -87,19 +118,38 @@ def render_rubric_form(
                 value=3,
                 key=f"{case_id}-{dim}",
             )
-        notes = st.text_area("Notes (no PHI)", max_chars=2000, key=f"{case_id}-notes")
+        notes_raw = st.text_area(
+            "Notes (no PHI — will be automatically scrubbed)",
+            max_chars=2000,
+            key=f"{case_id}-notes",
+        )
         submitted = st.form_submit_button("Submit grade")
 
     if not submitted:
         return None
+
+    scrub_result = scrub(notes_raw)
+    if scrub_result.failed:
+        st.error("Notes could not be processed; please remove special characters.")
+        logger.warning("notes scrub failed", extra={"reviewer_id": reviewer.user_id})
+        return None
+    if scrub_result.hits:
+        logger.info(
+            "notes redacted",
+            extra={
+                "reviewer_id": reviewer.user_id,
+                "patterns": list(scrub_result.hits),
+            },
+        )
+
     logger.info(
         "rubric submitted",
         extra={"case_id": case_id, "reviewer_id": reviewer.user_id},
     )
-    # RubricScores validates ranges; Streamlit's slider already enforces
-    # them but defence in depth is cheap.
-    _ = notes  # persisted by caller via build_grade(notes=notes)
-    return RubricScores(**scores)
+    return RubricSubmission(
+        scores=RubricScores(**scores),
+        notes=scrub_result.scrubbed,
+    )
 
 
 def render_provenance_panel(
@@ -130,16 +180,15 @@ def render_provenance_panel(
     st.components.v1.iframe(src=url, height=600, scrolling=True)
 
 
-def main(st: Any, *, request_headers: dict[str, str]) -> None:
-    """Entry point. `st` is the Streamlit module, injected for testability.
-
-    Streamlit's script-rerun model means this function runs on every
-    user interaction. We keep it small: resolve identity, dispatch to
-    the authorized or forbidden view.
-    """
-    claims = extract_claims_from_headers(request_headers)
+def main(
+    st: Any,
+    *,
+    request_headers: dict[str, str],
+    validator: OidcValidator | None,
+) -> None:
+    """Entry point. Resolves reviewer identity, dispatches views."""
     try:
-        reviewer = authorize_reviewer(claims)
+        reviewer = resolve_reviewer(headers=request_headers, validator=validator)
     except UnauthorizedError as exc:
         render_forbidden(st, reason=str(exc))
         return
@@ -150,10 +199,45 @@ def main(st: Any, *, request_headers: dict[str, str]) -> None:
         f"Signed in as {reviewer.display_name} ({reviewer.role}) · "
         f"{datetime.now(timezone.utc).strftime('%Y-%m-%d')}"
     )
-    # The actual case-loading loop (queue.reserve_next → render form →
-    # repository.insert_grade → queue.complete) is orchestrated by the
-    # thin runner in `labeling/runner.py` to keep this shell trivial.
+    # The case-loading loop (queue.reserve_next → render form →
+    # repository.insert_next_grade → queue.complete) is orchestrated
+    # by `labeling.runner` (not yet wired — lands with the container
+    # build in issue #34).
     st.info(
         "Fetch the next assigned case from the sidebar. "
         "Each grade is chained to your previous grade via a SHA-256 hash."
     )
+
+
+def _bootstrap() -> None:  # pragma: no cover - runtime-only wiring
+    """Streamlit runtime entry. Imports inside the function so unit tests
+    that import `labeling.app` do not pull in streamlit."""
+    import streamlit as st  # type: ignore[import-not-found]
+
+    from labeling.settings import LabelingSettings
+
+    settings = LabelingSettings()
+
+    validator: OidcValidator | None = None
+    if settings.oidc_issuer_url and settings.oidc_jwks_uri:
+        validator = OidcValidator.from_uri(
+            jwks_uri=settings.oidc_jwks_uri,
+            issuer=settings.oidc_issuer_url,
+            audience=settings.oidc_audience,
+        )
+
+    # Streamlit exposes incoming request headers via st.context.headers.
+    headers: dict[str, str] = {}
+    ctx_headers = getattr(getattr(st, "context", None), "headers", None)
+    if ctx_headers is not None:
+        headers = dict(ctx_headers)
+
+    main(st, request_headers=headers, validator=validator)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    # Streamlit runs `streamlit run labeling/app.py` which loads this
+    # module with __name__ == "__main__" and re-executes top-to-bottom
+    # on every user event. Unit tests import `labeling.app` (name !=
+    # __main__) so the bootstrap does not fire during pytest.
+    _bootstrap()

--- a/labeling/auth.py
+++ b/labeling/auth.py
@@ -1,0 +1,91 @@
+"""OIDC role gate for the labeling UI.
+
+The gateway already validates the OIDC JWT (backend/app/api/middleware.py).
+Streamlit sits behind the same ingress and receives the validated claims
+via the `X-Forwarded-Claims` header the gateway sets for downstream
+services. We re-validate the claims signature here because defence in
+depth is cheap and the labeling app hosts PHI-adjacent data (grades that
+reference case ids).
+
+Only `clinical_reviewer` and `senior_clinician` roles may grade. A user
+with neither role gets a 403-equivalent page.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+
+ALLOWED_ROLES: Final = frozenset({"clinical_reviewer", "senior_clinician"})
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizedReviewer:
+    """What the app needs from the JWT — no more, no less."""
+
+    user_id: str
+    role: str
+    display_name: str
+
+
+class UnauthorizedError(Exception):
+    """Caller lacks a valid role. Mapped to 403 by the Streamlit shell."""
+
+
+def authorize_reviewer(claims: dict[str, object]) -> AuthorizedReviewer:
+    """Extract reviewer identity from JWT claims; fail closed on any gap.
+
+    We require: `sub` (stable user id), a role in ALLOWED_ROLES, and a
+    display name (`preferred_username` or `name`). Missing `sub` is a
+    misconfigured IdP; we refuse rather than invent a synthetic id.
+    """
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise UnauthorizedError("missing sub claim")
+
+    role = _extract_role(claims)
+    if role not in ALLOWED_ROLES:
+        # Log user_id (opaque) but never log claim payload (may contain email).
+        logger.info(
+            "labeling access refused",
+            extra={"user_id": sub, "reason": "role_not_allowed"},
+        )
+        raise UnauthorizedError(f"role {role!r} not in {sorted(ALLOWED_ROLES)}")
+
+    display = claims.get("preferred_username") or claims.get("name") or sub
+    if not isinstance(display, str):
+        display = sub
+
+    return AuthorizedReviewer(user_id=sub, role=role, display_name=display)
+
+
+def _extract_role(claims: dict[str, object]) -> str:
+    """Pull role from claims. Preference: `role` string, then `roles` list.
+
+    Keycloak convention is `realm_access.roles` — we also support that
+    format by flattening. Returns "" when no role present (triggers a
+    refusal in the caller).
+    """
+    role = claims.get("role")
+    if isinstance(role, str) and role:
+        return role
+
+    roles = claims.get("roles")
+    if isinstance(roles, list):
+        for r in roles:
+            if isinstance(r, str) and r in ALLOWED_ROLES:
+                return r
+
+    realm_access = claims.get("realm_access")
+    if isinstance(realm_access, dict):
+        realm_roles = realm_access.get("roles")
+        if isinstance(realm_roles, list):
+            for r in realm_roles:
+                if isinstance(r, str) and r in ALLOWED_ROLES:
+                    return r
+
+    return ""

--- a/labeling/daily_kappa.py
+++ b/labeling/daily_kappa.py
@@ -1,0 +1,165 @@
+"""Daily Fleiss kappa job entrypoint.
+
+Reads the previous 24h of grades from the `grades` table, computes
+Fleiss kappa per rubric dimension over dual-rated cases, emits a
+Prometheus metric, and alerts when any dimension drops below
+`kappa_alert_threshold`.
+
+Run as a k3s CronJob at 03:00 Africa/Nairobi (after the labeling UI is
+quiet). Idempotent: re-running the same 24h window produces the same
+kappa values.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from labeling.kappa import build_counts_matrix, fleiss_kappa
+from labeling.repository import GradeRepository
+from labeling.rubric import RUBRIC_DIMENSIONS, SCALE_MAX, SCALE_MIN
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class KappaReport:
+    """Per-dimension kappa with metadata for Slack / Prometheus."""
+
+    window_start: datetime
+    window_end: datetime
+    dimension_kappa: dict[str, float]
+    dimension_n_items: dict[str, int]
+    alerts: tuple[str, ...]
+
+
+_N_CATEGORIES = SCALE_MAX - SCALE_MIN + 1
+
+
+async def run_daily_kappa(
+    *,
+    repository: GradeRepository,
+    now: datetime,
+    alert_threshold: float,
+    min_raters_per_item: int = 2,
+) -> KappaReport:
+    """Compute kappa for the 24h window ending at `now`.
+
+    Cases with fewer than `min_raters_per_item` raters are dropped (kappa
+    requires ≥2 raters per item). If *all* cases are single-rated for a
+    dimension, kappa is reported as nan and no alert fires — "not enough
+    data" is not the same as "poor agreement."
+    """
+    if alert_threshold < -1.0 or alert_threshold > 1.0:
+        raise ValueError("alert_threshold must be in [-1, 1]")
+
+    window_end = now.astimezone(timezone.utc)
+    window_start = window_end - timedelta(days=1)
+
+    ratings_by_case = await repository.load_agreement_ratings(
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+    dimension_kappa: dict[str, float] = {}
+    dimension_n: dict[str, int] = {}
+    alerts: list[str] = []
+
+    for dim in RUBRIC_DIMENSIONS:
+        per_item_labels: list[list[int]] = []
+        for _case_id, by_dim in ratings_by_case.items():
+            ratings = by_dim.get(dim, [])
+            if len(ratings) < min_raters_per_item:
+                continue
+            labels = [r["score"] - SCALE_MIN for r in ratings]
+            per_item_labels.append(labels)
+
+        dimension_n[dim] = len(per_item_labels)
+        if not per_item_labels:
+            dimension_kappa[dim] = float("nan")
+            continue
+
+        # Fleiss requires equal rater count per item. Truncate all items
+        # to the minimum rater count so we can still report when some
+        # cases had 2 reviewers and others had 3.
+        min_raters = min(len(row) for row in per_item_labels)
+        truncated = [row[:min_raters] for row in per_item_labels]
+
+        counts = build_counts_matrix(
+            ratings_per_item=truncated,
+            n_categories=_N_CATEGORIES,
+        )
+        result = fleiss_kappa(item_rater_category_counts=counts)
+        dimension_kappa[dim] = result.kappa
+
+        if result.kappa < alert_threshold and not _is_nan(result.kappa):
+            alerts.append(
+                f"{dim}:{result.kappa:.3f}<{alert_threshold:.2f}"
+                f" (n_items={len(truncated)})"
+            )
+
+    report = KappaReport(
+        window_start=window_start,
+        window_end=window_end,
+        dimension_kappa=dimension_kappa,
+        dimension_n_items=dimension_n,
+        alerts=tuple(alerts),
+    )
+    logger.info(
+        "kappa report computed",
+        extra={
+            "window_start": window_start.isoformat(),
+            "window_end": window_end.isoformat(),
+            "dimension_kappa": dimension_kappa,
+            "dimension_n_items": dimension_n,
+            "n_alerts": len(alerts),
+        },
+    )
+    return report
+
+
+def _is_nan(x: float) -> bool:
+    return x != x
+
+
+async def _main() -> int:  # pragma: no cover - thin integration shim
+    import os
+
+    import asyncpg  # type: ignore[import-not-found]
+
+    from labeling.settings import LabelingSettings
+
+    settings = LabelingSettings()
+    pool = await asyncpg.create_pool(
+        host=settings.pg_host,
+        port=settings.pg_port,
+        database=settings.pg_database,
+        user=settings.pg_user,
+        password=settings.pg_password,
+        min_size=settings.pg_pool_min,
+        max_size=settings.pg_pool_max,
+    )
+    try:
+        repo = GradeRepository(
+            pool=pool,
+            statement_timeout_ms=settings.pg_statement_timeout_ms,
+        )
+        report = await run_daily_kappa(
+            repository=repo,
+            now=datetime.now(timezone.utc),
+            alert_threshold=settings.kappa_alert_threshold,
+        )
+        if report.alerts:
+            print("kappa alerts:")  # noqa: T201  # CronJob stdout is the channel.
+            for alert in report.alerts:
+                print(f"  {alert}")  # noqa: T201
+            return 1 if os.environ.get("KAPPA_FAIL_ON_ALERT") == "1" else 0
+        return 0
+    finally:
+        await pool.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(asyncio.run(_main()))

--- a/labeling/daily_kappa.py
+++ b/labeling/daily_kappa.py
@@ -152,9 +152,8 @@ async def _main() -> int:  # pragma: no cover - thin integration shim
             alert_threshold=settings.kappa_alert_threshold,
         )
         if report.alerts:
-            print("kappa alerts:")  # noqa: T201  # CronJob stdout is the channel.
             for alert in report.alerts:
-                print(f"  {alert}")  # noqa: T201
+                logger.warning("kappa alert", extra={"alert": alert})
             return 1 if os.environ.get("KAPPA_FAIL_ON_ALERT") == "1" else 0
         return 0
     finally:

--- a/labeling/jwt_validator.py
+++ b/labeling/jwt_validator.py
@@ -1,0 +1,78 @@
+"""OIDC JWT validator.
+
+Wraps PyJWT + a JWKS client. Verifies signature, expiry, audience, and
+issuer. Raises `InvalidTokenError` on any failure; never returns
+silently on an invalid token.
+
+Kept tiny and protocol-friendly so unit tests can inject a fake JWKS
+client (tests at `tests/test_jwt_validator.py`). The actual JWKS fetch
+happens at app startup via `OidcValidator.from_uri` — same pattern as
+the gateway's `backend/app/api/middleware.py`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidTokenError(Exception):
+    """Raised for any JWT validation failure — expiry, bad sig, wrong aud."""
+
+
+class SigningKeyLike(Protocol):
+    key: Any
+
+
+class JwksClientLike(Protocol):
+    def get_signing_key_from_jwt(self, token: str) -> SigningKeyLike: ...
+
+
+@dataclass(frozen=True, slots=True)
+class OidcValidator:
+    jwks_client: JwksClientLike
+    issuer: str
+    audience: str
+    algorithms: tuple[str, ...] = ("RS256",)
+
+    @classmethod
+    def from_uri(
+        cls,
+        *,
+        jwks_uri: str,
+        issuer: str,
+        audience: str,
+    ) -> OidcValidator:  # pragma: no cover - network
+        """Construct a validator backed by PyJWT's PyJWKClient."""
+        import jwt  # type: ignore[import-untyped]
+
+        return cls(
+            jwks_client=jwt.PyJWKClient(jwks_uri),
+            issuer=issuer,
+            audience=audience,
+        )
+
+    def validate(self, token: str) -> dict[str, object]:
+        """Validate and decode. Raise InvalidTokenError on any failure."""
+        if not token:
+            raise InvalidTokenError("empty token")
+        try:
+            import jwt  # type: ignore[import-untyped]
+
+            signing_key = self.jwks_client.get_signing_key_from_jwt(token)
+            claims = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=list(self.algorithms),
+                audience=self.audience,
+                issuer=self.issuer,
+            )
+        except Exception as exc:  # PyJWT raises many subclasses; unify.
+            logger.info("jwt validation failed", extra={"error": str(exc)})
+            raise InvalidTokenError(str(exc)) from exc
+        if not isinstance(claims, dict):
+            raise InvalidTokenError("decoded claims not a dict")
+        return claims

--- a/labeling/kappa.py
+++ b/labeling/kappa.py
@@ -1,0 +1,129 @@
+"""Fleiss kappa inter-rater agreement.
+
+Fleiss kappa generalises Cohen's kappa to more than two raters. It
+measures agreement above chance across a fixed number of raters per
+item (here, 3 for dual-rated cases). Values:
+
+    1.00  perfect agreement
+    0.00  agreement at chance level
+   <0.00  worse than chance (raters systematically disagreeing)
+
+For clinical rubrics we alert below 0.70.
+
+Pure math. No I/O. Tests in `tests/test_kappa.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class FleissKappaResult:
+    """Kappa plus the working terms, useful for debugging."""
+
+    kappa: float
+    n_items: int
+    n_raters: int
+    n_categories: int
+    p_mean_agreement: float
+    p_expected_by_chance: float
+
+
+def fleiss_kappa(*, item_rater_category_counts: list[list[int]]) -> FleissKappaResult:
+    """Compute Fleiss kappa over N items × K categories.
+
+    `item_rater_category_counts[i][k]` = number of raters who assigned
+    item i to category k. Every row must sum to the same number of
+    raters (`n`). Items with inconsistent rater counts raise ValueError.
+
+    Returns `FleissKappaResult(kappa=nan, ...)` when agreement is
+    undefined (single category with all ratings → both P_mean and P_e
+    equal 1, so kappa is 0/0). The caller treats nan as "degenerate"
+    and does not alert.
+    """
+    if not item_rater_category_counts:
+        raise ValueError("item_rater_category_counts is empty")
+
+    n_items = len(item_rater_category_counts)
+    k = len(item_rater_category_counts[0])
+    if k == 0:
+        raise ValueError("no categories in first item")
+
+    # Validate shape + constant rater count
+    n = sum(item_rater_category_counts[0])
+    if n < 2:
+        raise ValueError(f"need at least 2 raters per item, got n={n}")
+    for i, row in enumerate(item_rater_category_counts):
+        if len(row) != k:
+            raise ValueError(f"item {i} has {len(row)} categories, expected {k}")
+        if sum(row) != n:
+            raise ValueError(
+                f"item {i} has {sum(row)} raters, expected {n} (from item 0)"
+            )
+        for count in row:
+            if count < 0:
+                raise ValueError(f"item {i} has negative count")
+
+    # P_i: agreement for item i, averaged over pairs of raters
+    # P_i = (1 / (n*(n-1))) * (Σ_k n_ik² − n)
+    p_items: list[float] = []
+    for row in item_rater_category_counts:
+        sum_sq = sum(count * count for count in row)
+        p_i = (sum_sq - n) / (n * (n - 1))
+        p_items.append(p_i)
+    p_mean = sum(p_items) / n_items
+
+    # p_j: proportion of all ratings assigned to category j
+    total_ratings = n * n_items
+    p_cat: list[float] = []
+    for j in range(k):
+        column_sum = sum(row[j] for row in item_rater_category_counts)
+        p_cat.append(column_sum / total_ratings)
+
+    p_expected = sum(p * p for p in p_cat)
+
+    denom = 1.0 - p_expected
+    if denom == 0.0:
+        # Degenerate: all raters agreed on a single category for every item.
+        # Kappa is undefined; signal with nan.
+        kappa = float("nan")
+    else:
+        kappa = (p_mean - p_expected) / denom
+
+    return FleissKappaResult(
+        kappa=kappa,
+        n_items=n_items,
+        n_raters=n,
+        n_categories=k,
+        p_mean_agreement=p_mean,
+        p_expected_by_chance=p_expected,
+    )
+
+
+def build_counts_matrix(
+    *,
+    ratings_per_item: list[list[int]],
+    n_categories: int,
+) -> list[list[int]]:
+    """Turn per-item rating lists into the Fleiss counts matrix.
+
+    `ratings_per_item[i]` is the list of category labels (0-indexed,
+    0..n_categories-1) assigned by each rater to item i. All items must
+    be rated by the same number of raters.
+    """
+    if not ratings_per_item:
+        return []
+    if n_categories <= 0:
+        raise ValueError("n_categories must be positive")
+    out: list[list[int]] = []
+    for i, ratings in enumerate(ratings_per_item):
+        counts = [0] * n_categories
+        for label in ratings:
+            if label < 0 or label >= n_categories:
+                raise ValueError(
+                    f"item {i}: category label {label} outside [0, {n_categories})"
+                )
+            counts[label] += 1
+        out.append(counts)
+    return out

--- a/labeling/pdf_viewer.py
+++ b/labeling/pdf_viewer.py
@@ -1,0 +1,66 @@
+"""PDF provenance viewer URL builder.
+
+The labeling UI embeds the gateway's provenance viewer via an iframe.
+The viewer supports deep-linking to a specific page + bbox via query
+params; we construct the URL here so the Streamlit app stays ignorant
+of the viewer's routing.
+
+Pure string building. No I/O. No external calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import quote, urlencode
+
+
+@dataclass(frozen=True, slots=True)
+class BoundingBox:
+    """Normalised PDF page coordinates (0..1 in both axes, origin top-left)."""
+
+    page: int
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+
+    def __post_init__(self) -> None:
+        if self.page < 1:
+            raise ValueError("page must be >= 1")
+        for coord_name in ("x0", "y0", "x1", "y1"):
+            v = getattr(self, coord_name)
+            if not (0.0 <= v <= 1.0):
+                raise ValueError(f"{coord_name}={v} outside [0, 1]")
+        if self.x0 >= self.x1 or self.y0 >= self.y1:
+            raise ValueError(
+                "bbox must have x0 < x1 and y0 < y1 "
+                f"(got x0={self.x0}, x1={self.x1}, y0={self.y0}, y1={self.y1})"
+            )
+
+
+def build_viewer_url(
+    *,
+    base_url: str,
+    document_id: str,
+    bbox: BoundingBox | None,
+    highlight: bool = True,
+) -> str:
+    """Compose a deep link into the provenance viewer.
+
+    When `bbox` is None, the link opens the document at page 1 with no
+    highlight. When `highlight=False` we still pass the page so the
+    reviewer lands on the right spot.
+    """
+    if not base_url:
+        raise ValueError("base_url is required")
+    # Strip trailing slash — the viewer uses `/<doc_id>` as its path.
+    base = base_url.rstrip("/")
+    doc_path = quote(document_id, safe="")
+    params: dict[str, str] = {}
+    if bbox is not None:
+        params["page"] = str(bbox.page)
+        if highlight:
+            # Viewer expects `bbox=x0,y0,x1,y1` in normalised coords.
+            params["bbox"] = f"{bbox.x0:.4f},{bbox.y0:.4f},{bbox.x1:.4f},{bbox.y1:.4f}"
+    query = f"?{urlencode(params)}" if params else ""
+    return f"{base}/{doc_path}{query}"

--- a/labeling/phi.py
+++ b/labeling/phi.py
@@ -1,0 +1,63 @@
+"""Labeling-local PHI scrubber.
+
+Delegates to `backend.app.validation.phi.scrub` when the backend package
+is importable (production image mounts both). In the standalone
+labeling image (which does not ship the backend package) we fall back
+to a minimal, stricter local regex set covering the fields that a
+reviewer is most likely to paste: Kenyan national IDs, MRNs, phone
+numbers, email addresses.
+
+The scrubber fails closed: on any regex compilation or runtime error,
+the caller treats the result as "not safe to store" and refuses the
+submission.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+REPLACEMENT: Final[str] = "<REDACTED>"
+
+
+@dataclass(frozen=True, slots=True)
+class ScrubResult:
+    scrubbed: str
+    hits: tuple[str, ...]
+    failed: bool
+
+
+_PATTERNS: Final[tuple[tuple[str, re.Pattern[str]], ...]] = (
+    # Kenyan national ID — 8 digits, standalone.
+    ("national_id", re.compile(r"(?<!\d)\d{8}(?!\d)")),
+    # MRN: optional 1-3 letter prefix + 4-8 digits.
+    ("mrn", re.compile(r"\b[A-Z]{1,3}-?\d{4,8}\b")),
+    # Kenyan mobile: +254 7XX XXX XXX or 07XX XXX XXX.
+    ("phone", re.compile(r"(?:\+?254|0)[\s-]?7\d{2}[\s-]?\d{3}[\s-]?\d{3}")),
+    # Email.
+    ("email", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")),
+)
+
+
+def scrub(text: str, *, replacement: str = REPLACEMENT) -> ScrubResult:
+    """Redact PHI-like patterns. Fails closed on any exception.
+
+    Returns `ScrubResult(scrubbed, hits, failed)`. `hits` contains the
+    pattern names that fired at least once; `failed=True` means the
+    scrubber itself raised and the caller MUST NOT store the text.
+    """
+    if not isinstance(text, str):
+        return ScrubResult(scrubbed="", hits=(), failed=True)
+    try:
+        out = text
+        hits: list[str] = []
+        for name, pattern in _PATTERNS:
+            new_out, n = pattern.subn(replacement, out)
+            if n > 0:
+                hits.append(name)
+            out = new_out
+        return ScrubResult(scrubbed=out, hits=tuple(hits), failed=False)
+    except re.error:
+        # Should never happen (patterns are static) but fail closed.
+        return ScrubResult(scrubbed="", hits=(), failed=True)

--- a/labeling/pyproject.toml
+++ b/labeling/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "afya-sahihi-labeling"
+version = "0.0.1"
+description = "Afya Sahihi Tier 3 labeling UI — Streamlit clinician reviewer."
+requires-python = "==3.12.*"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Aga Khan University" }]
+
+# Pure-Python core (rubric, kappa, auth gate, queue keys, URL builder)
+# imports without streamlit/redis/asyncpg. The Streamlit shell and the
+# Redis + asyncpg clients are extras so CI can unit-test the math
+# without installing the full UI stack. ADR-0009.
+dependencies = [
+    "pydantic==2.9.2",
+    "pydantic-settings==2.6.1",
+]
+
+[project.optional-dependencies]
+ui = [
+    "streamlit==1.39.0",
+    "redis==5.2.1",
+    "asyncpg==0.30.0",
+    "PyJWT[crypto]==2.12.0",
+    "prometheus-client==0.21.1",
+]
+dev = [
+    "pytest==8.3.3",
+    "pytest-asyncio==0.24.0",
+    "ruff==0.6.9",
+    "pyright==1.1.384",
+]
+
+[build-system]
+requires = ["hatchling>=1.25.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/labeling/queue.py
+++ b/labeling/queue.py
@@ -1,0 +1,140 @@
+"""Redis-backed case assignment queue.
+
+Each reviewer sees a weekly queue of case ids. The backend (out of
+scope for this PR) pre-populates the queue via the active-learning
+acquisition job (M9, issue #37). We read from it here.
+
+Operations are atomic — `reserve` uses LREM+LPUSH to move the case
+into the reviewer's in-flight list; `submit` removes it from in-flight
+and pushes its id onto the completed set. Reserving guards against
+two reviewers accidentally grading the same case twice (which would
+fake agreement).
+
+Depends on the `redis` client (already in backend/pyproject.toml).
+Uses a Protocol so tests can inject a fake. Every call has an
+asyncio.timeout and every error path fails closed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class RedisLike(Protocol):
+    """Subset of redis.asyncio.Redis we use. Keeps tests pure."""
+
+    async def lrange(self, key: str, start: int, end: int) -> list[bytes]: ...
+    async def lrem(self, key: str, count: int, value: str) -> int: ...
+    async def rpush(self, key: str, *values: str) -> int: ...
+    async def sadd(self, key: str, *values: str) -> int: ...
+    async def smembers(self, key: str) -> set[bytes]: ...
+    async def scard(self, key: str) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class QueueKeys:
+    """Key pattern for a reviewer's week."""
+
+    pending: str
+    in_flight: str
+    completed: str
+
+    @classmethod
+    def for_reviewer(
+        cls,
+        *,
+        base_key: str,
+        reviewer_id: str,
+        iso_week: str,
+    ) -> QueueKeys:
+        """base_key + reviewer_id + ISO week → namespaced key set."""
+        # iso_week like "2026-W16"; reviewer_id from OIDC sub (opaque).
+        prefix = f"{base_key}:{reviewer_id}:{iso_week}"
+        return cls(
+            pending=f"{prefix}:pending",
+            in_flight=f"{prefix}:in_flight",
+            completed=f"{prefix}:completed",
+        )
+
+
+class ReviewerCaseQueue:
+    """One reviewer's weekly queue. Scoped by QueueKeys."""
+
+    def __init__(
+        self,
+        *,
+        redis: RedisLike,
+        keys: QueueKeys,
+        timeout_seconds: float = 2.0,
+    ) -> None:
+        self._redis = redis
+        self._keys = keys
+        self._timeout = timeout_seconds
+
+    async def list_pending(self, *, limit: int = 50) -> list[str]:
+        """Cases waiting to be reserved. Bounded to `limit` for safety."""
+        if limit <= 0:
+            return []
+        async with asyncio.timeout(self._timeout):
+            raw = await self._redis.lrange(self._keys.pending, 0, limit - 1)
+        return [_decode(item) for item in raw]
+
+    async def reserve_next(self) -> str | None:
+        """Atomically move the head of pending → in-flight. Returns case_id or None.
+
+        We do this as LRANGE+LREM+RPUSH rather than LMOVE so we can run
+        against older Redis servers without ACL gymnastics. Two reviewers
+        racing on the same pending case will see one succeed (LREM returns
+        1) and the other get zero, returning None.
+        """
+        async with asyncio.timeout(self._timeout):
+            head = await self._redis.lrange(self._keys.pending, 0, 0)
+            if not head:
+                return None
+            case_id = _decode(head[0])
+            removed = await self._redis.lrem(self._keys.pending, 1, case_id)
+            if removed == 0:
+                # Another reviewer got it first.
+                return None
+            await self._redis.rpush(self._keys.in_flight, case_id)
+        return case_id
+
+    async def complete(self, case_id: str) -> bool:
+        """Move case from in-flight → completed set. Returns True if it was in-flight.
+
+        Completion is idempotent: calling twice returns False the second
+        time. We still attempt to add to `completed` to keep analytics
+        consistent after a retry.
+        """
+        if not case_id:
+            raise ValueError("case_id required")
+        async with asyncio.timeout(self._timeout):
+            removed = await self._redis.lrem(self._keys.in_flight, 1, case_id)
+            await self._redis.sadd(self._keys.completed, case_id)
+        return removed > 0
+
+    async def release(self, case_id: str) -> bool:
+        """Abandon an in-flight case back to pending. Returns True if returned."""
+        if not case_id:
+            raise ValueError("case_id required")
+        async with asyncio.timeout(self._timeout):
+            removed = await self._redis.lrem(self._keys.in_flight, 1, case_id)
+            if removed == 0:
+                return False
+            await self._redis.rpush(self._keys.pending, case_id)
+        return True
+
+    async def completed_count(self) -> int:
+        async with asyncio.timeout(self._timeout):
+            return await self._redis.scard(self._keys.completed)
+
+
+def _decode(value: bytes | str) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value

--- a/labeling/repository.py
+++ b/labeling/repository.py
@@ -1,22 +1,30 @@
 """Grade persistence and agreement-set loading.
 
 Two responsibilities:
-  1. `insert_grade` — write a reviewer's scored case to `grades` with
-     chain-of-custody. SET LOCAL statement_timeout enforced.
-  2. `load_agreement_matrix` — pull dual-rated cases for daily Fleiss
-     kappa computation. Returns per-case × per-dimension rating lists.
+  1. `insert_next_grade` — read latest row_hash, compute new row_hash,
+     insert, all inside one SERIALIZABLE transaction per reviewer so
+     concurrent submissions cannot fork the hash chain. SET LOCAL
+     statement_timeout enforced.
+  2. `load_agreement_ratings` — pull grades in a time window grouped by
+     case then dimension for daily Fleiss kappa.
 
-We use a Protocol for the pool so unit tests can inject a fake without
-testcontainers. Integration tests (in the backend suite) exercise the
-real SQL against a seeded Postgres.
+We use Protocols for pool/connection so unit tests can inject a fake
+without testcontainers. Integration tests (landing with backend's test
+suite) exercise the real SQL against a seeded Postgres.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any, Protocol
 
-from labeling.rubric import RUBRIC_DIMENSIONS, Grade, grade_to_row_dict
+from labeling.rubric import (
+    RUBRIC_DIMENSIONS,
+    RubricScores,
+    build_grade,
+    grade_to_row_dict,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +53,17 @@ WHERE submitted_at >= $1 AND submitted_at < $2
 ORDER BY case_id, submitted_at;
 """
 
+# pg_advisory_xact_lock serialises concurrent writes per reviewer so the
+# latest_hash → insert read-modify-write cycle is atomic. Using hashtext
+# keeps the lock key within int4 regardless of reviewer_id length.
+_ADVISORY_LOCK_SQL = "SELECT pg_advisory_xact_lock(hashtext($1));"
+
 
 class ConnectionLike(Protocol):
     async def execute(self, query: str, *args: Any) -> Any: ...
     async def fetchval(self, query: str, *args: Any) -> Any: ...
     async def fetch(self, query: str, *args: Any) -> list[Any]: ...
+    def transaction(self, **kwargs: Any) -> Any: ...
 
 
 class PoolLike(Protocol):
@@ -63,53 +77,81 @@ class GradeRepository:
         self._pool = pool
         self._timeout_ms = statement_timeout_ms
 
-    async def latest_row_hash(self, *, reviewer_id: str) -> str:
-        """Most recent row_hash for this reviewer, or '' if they have no rows.
+    async def insert_next_grade(
+        self,
+        *,
+        grade_id: str,
+        case_id: str,
+        reviewer_id: str,
+        reviewer_role: str,
+        rubric_version: str,
+        scores: RubricScores,
+        notes: str,
+        time_spent_seconds: int,
+        submitted_at: datetime,
+    ) -> str:
+        """Atomically chain and insert a grade for `reviewer_id`.
 
-        The labeling UI chains its submissions per reviewer, so a new
-        grade's prev_hash is this function's return value. A reviewer's
-        first grade chains off the empty string (genesis).
+        Inside one transaction:
+          1. Take an advisory lock keyed on reviewer_id (serialises
+             concurrent writers by that reviewer).
+          2. Read the reviewer's most recent row_hash as prev_hash.
+          3. Compute row_hash deterministically over the payload.
+          4. INSERT.
+
+        Returns the computed row_hash. The caller can verify the chain
+        by re-running compute_row_hash over the payload.
         """
         async with self._pool.acquire() as conn:
-            await conn.execute(f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'")
-            value = await conn.fetchval(_LATEST_HASH_SQL, reviewer_id)
-        if value is None:
-            return ""
-        if isinstance(value, str):
-            return value
-        raise TypeError(f"unexpected row_hash type: {type(value).__name__}")
+            async with conn.transaction():
+                await conn.execute(
+                    f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'"
+                )
+                await conn.execute(_ADVISORY_LOCK_SQL, reviewer_id)
 
-    async def insert_grade(self, grade: Grade) -> None:
-        """Persist a grade. Fails closed: any error propagates."""
-        row = grade_to_row_dict(grade)
-        async with self._pool.acquire() as conn:
-            await conn.execute(f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'")
-            await conn.execute(
-                _INSERT_SQL,
-                row["grade_id"],
-                row["case_id"],
-                row["reviewer_id"],
-                row["reviewer_role"],
-                row["rubric_version"],
-                row["accuracy"],
-                row["safety"],
-                row["guideline_alignment"],
-                row["local_appropriateness"],
-                row["clarity"],
-                row["notes"],
-                row["time_spent_seconds"],
-                row["submitted_at"],
-                row["prev_hash"],
-                row["row_hash"],
-            )
+                prev_hash_raw = await conn.fetchval(_LATEST_HASH_SQL, reviewer_id)
+                prev_hash = prev_hash_raw if isinstance(prev_hash_raw, str) else ""
+
+                grade = build_grade(
+                    grade_id=grade_id,
+                    case_id=case_id,
+                    reviewer_id=reviewer_id,
+                    reviewer_role=reviewer_role,
+                    rubric_version=rubric_version,
+                    scores=scores,
+                    notes=notes,
+                    time_spent_seconds=time_spent_seconds,
+                    submitted_at=submitted_at,
+                    prev_hash=prev_hash,
+                )
+                row = grade_to_row_dict(grade)
+                await conn.execute(
+                    _INSERT_SQL,
+                    row["grade_id"],
+                    row["case_id"],
+                    row["reviewer_id"],
+                    row["reviewer_role"],
+                    row["rubric_version"],
+                    row["accuracy"],
+                    row["safety"],
+                    row["guideline_alignment"],
+                    row["local_appropriateness"],
+                    row["clarity"],
+                    row["notes"],
+                    row["time_spent_seconds"],
+                    row["submitted_at"],
+                    row["prev_hash"],
+                    row["row_hash"],
+                )
         logger.info(
             "grade persisted",
             extra={
-                "grade_id": grade.grade_id,
-                "case_id": grade.case_id,
-                "reviewer_role": grade.reviewer_role,
+                "grade_id": grade_id,
+                "case_id": case_id,
+                "reviewer_role": reviewer_role,
             },
         )
+        return grade.row_hash
 
     async def load_agreement_ratings(
         self,
@@ -120,12 +162,15 @@ class GradeRepository:
         """Return ratings grouped by case then dimension for the window.
 
         Shape: `{case_id: {dimension: [{"reviewer_id": rid, "score": s}, ...]}}`.
-        The daily kappa job picks up this structure, filters to cases
-        with >= 2 raters, and computes Fleiss kappa per dimension.
+        Read-only so we still open a transaction for the SET LOCAL
+        timeout but no lock is taken.
         """
         async with self._pool.acquire() as conn:
-            await conn.execute(f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'")
-            rows = await conn.fetch(_AGREEMENT_SQL, window_start, window_end)
+            async with conn.transaction():
+                await conn.execute(
+                    f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'"
+                )
+                rows = await conn.fetch(_AGREEMENT_SQL, window_start, window_end)
 
         out: dict[str, dict[str, list[dict[str, int]]]] = {}
         for row in rows:

--- a/labeling/repository.py
+++ b/labeling/repository.py
@@ -1,0 +1,137 @@
+"""Grade persistence and agreement-set loading.
+
+Two responsibilities:
+  1. `insert_grade` — write a reviewer's scored case to `grades` with
+     chain-of-custody. SET LOCAL statement_timeout enforced.
+  2. `load_agreement_matrix` — pull dual-rated cases for daily Fleiss
+     kappa computation. Returns per-case × per-dimension rating lists.
+
+We use a Protocol for the pool so unit tests can inject a fake without
+testcontainers. Integration tests (in the backend suite) exercise the
+real SQL against a seeded Postgres.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from labeling.rubric import RUBRIC_DIMENSIONS, Grade, grade_to_row_dict
+
+logger = logging.getLogger(__name__)
+
+
+_INSERT_SQL = """
+INSERT INTO grades (
+    grade_id, case_id, reviewer_id, reviewer_role, rubric_version,
+    accuracy, safety, guideline_alignment, local_appropriateness, clarity,
+    notes, time_spent_seconds, submitted_at, prev_hash, row_hash
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15);
+"""
+
+_LATEST_HASH_SQL = """
+SELECT row_hash
+FROM grades
+WHERE reviewer_id = $1
+ORDER BY submitted_at DESC
+LIMIT 1;
+"""
+
+_AGREEMENT_SQL = """
+SELECT case_id, reviewer_id, accuracy, safety, guideline_alignment,
+       local_appropriateness, clarity
+FROM grades
+WHERE submitted_at >= $1 AND submitted_at < $2
+ORDER BY case_id, submitted_at;
+"""
+
+
+class ConnectionLike(Protocol):
+    async def execute(self, query: str, *args: Any) -> Any: ...
+    async def fetchval(self, query: str, *args: Any) -> Any: ...
+    async def fetch(self, query: str, *args: Any) -> list[Any]: ...
+
+
+class PoolLike(Protocol):
+    def acquire(self) -> Any: ...
+
+
+class GradeRepository:
+    """Write-and-read layer for grades. Raw SQL per ADR-0008."""
+
+    def __init__(self, *, pool: PoolLike, statement_timeout_ms: int = 5000) -> None:
+        self._pool = pool
+        self._timeout_ms = statement_timeout_ms
+
+    async def latest_row_hash(self, *, reviewer_id: str) -> str:
+        """Most recent row_hash for this reviewer, or '' if they have no rows.
+
+        The labeling UI chains its submissions per reviewer, so a new
+        grade's prev_hash is this function's return value. A reviewer's
+        first grade chains off the empty string (genesis).
+        """
+        async with self._pool.acquire() as conn:
+            await conn.execute(f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'")
+            value = await conn.fetchval(_LATEST_HASH_SQL, reviewer_id)
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        raise TypeError(f"unexpected row_hash type: {type(value).__name__}")
+
+    async def insert_grade(self, grade: Grade) -> None:
+        """Persist a grade. Fails closed: any error propagates."""
+        row = grade_to_row_dict(grade)
+        async with self._pool.acquire() as conn:
+            await conn.execute(f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'")
+            await conn.execute(
+                _INSERT_SQL,
+                row["grade_id"],
+                row["case_id"],
+                row["reviewer_id"],
+                row["reviewer_role"],
+                row["rubric_version"],
+                row["accuracy"],
+                row["safety"],
+                row["guideline_alignment"],
+                row["local_appropriateness"],
+                row["clarity"],
+                row["notes"],
+                row["time_spent_seconds"],
+                row["submitted_at"],
+                row["prev_hash"],
+                row["row_hash"],
+            )
+        logger.info(
+            "grade persisted",
+            extra={
+                "grade_id": grade.grade_id,
+                "case_id": grade.case_id,
+                "reviewer_role": grade.reviewer_role,
+            },
+        )
+
+    async def load_agreement_ratings(
+        self,
+        *,
+        window_start: Any,
+        window_end: Any,
+    ) -> dict[str, dict[str, list[dict[str, int]]]]:
+        """Return ratings grouped by case then dimension for the window.
+
+        Shape: `{case_id: {dimension: [{"reviewer_id": rid, "score": s}, ...]}}`.
+        The daily kappa job picks up this structure, filters to cases
+        with >= 2 raters, and computes Fleiss kappa per dimension.
+        """
+        async with self._pool.acquire() as conn:
+            await conn.execute(f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'")
+            rows = await conn.fetch(_AGREEMENT_SQL, window_start, window_end)
+
+        out: dict[str, dict[str, list[dict[str, int]]]] = {}
+        for row in rows:
+            case_id = row["case_id"]
+            reviewer_id = row["reviewer_id"]
+            by_dim = out.setdefault(case_id, {dim: [] for dim in RUBRIC_DIMENSIONS})
+            for dim in RUBRIC_DIMENSIONS:
+                by_dim[dim].append({"reviewer_id": reviewer_id, "score": int(row[dim])})
+        return out

--- a/labeling/rubric.py
+++ b/labeling/rubric.py
@@ -1,0 +1,167 @@
+"""Rubric and grade value objects.
+
+The rubric has five dimensions, each scored on a 1-5 integer scale
+(Likert-like). A `Grade` bundles those five scores with chain-of-custody
+fields (reviewer id, timestamps, row_hash) so downstream analysis can
+detect tampering without trusting the application layer.
+
+Pure value objects. No I/O. Tests in `tests/test_rubric.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Final
+
+RUBRIC_DIMENSIONS: Final = (
+    "accuracy",
+    "safety",
+    "guideline_alignment",
+    "local_appropriateness",
+    "clarity",
+)
+SCALE_MIN: Final = 1
+SCALE_MAX: Final = 5
+
+
+@dataclass(frozen=True, slots=True)
+class RubricScores:
+    """Per-dimension scores. Every dimension mandatory; enforced in __post_init__."""
+
+    accuracy: int
+    safety: int
+    guideline_alignment: int
+    local_appropriateness: int
+    clarity: int
+
+    def __post_init__(self) -> None:
+        for dim in RUBRIC_DIMENSIONS:
+            value = getattr(self, dim)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError(f"{dim} must be int, got {type(value).__name__}")
+            if value < SCALE_MIN or value > SCALE_MAX:
+                raise ValueError(
+                    f"{dim}={value} out of range [{SCALE_MIN}, {SCALE_MAX}]"
+                )
+
+    def to_dict(self) -> dict[str, int]:
+        return {dim: getattr(self, dim) for dim in RUBRIC_DIMENSIONS}
+
+
+@dataclass(frozen=True, slots=True)
+class Grade:
+    """A single reviewer's grade for a single case, with chain-of-custody.
+
+    `row_hash` is computed by `compute_row_hash` from the canonicalised
+    payload plus `prev_hash`. Tampering with any field invalidates the
+    hash chain — verifiable offline by re-running `compute_row_hash`.
+    """
+
+    grade_id: str
+    case_id: str
+    reviewer_id: str
+    reviewer_role: str
+    rubric_version: str
+    scores: RubricScores
+    notes: str  # Scrubbed of PHI before passing here.
+    time_spent_seconds: int
+    submitted_at: datetime
+    prev_hash: str
+    row_hash: str
+
+    def __post_init__(self) -> None:
+        if self.time_spent_seconds < 0:
+            raise ValueError("time_spent_seconds must be >= 0")
+        if len(self.notes) > 2000:
+            raise ValueError("notes exceeds 2000 chars")
+
+
+def compute_row_hash(
+    *,
+    grade_id: str,
+    case_id: str,
+    reviewer_id: str,
+    reviewer_role: str,
+    rubric_version: str,
+    scores: RubricScores,
+    notes: str,
+    time_spent_seconds: int,
+    submitted_at: datetime,
+    prev_hash: str,
+) -> str:
+    """SHA-256 over the canonical payload. Deterministic.
+
+    submitted_at is serialised as ISO-8601 UTC with microsecond precision.
+    Any change to any input — including reordering scores — changes the
+    hash, so the chain detects tampering at any field granularity.
+    """
+    if submitted_at.tzinfo is None:
+        raise ValueError("submitted_at must be timezone-aware")
+    payload = {
+        "grade_id": grade_id,
+        "case_id": case_id,
+        "reviewer_id": reviewer_id,
+        "reviewer_role": reviewer_role,
+        "rubric_version": rubric_version,
+        "scores": scores.to_dict(),
+        "notes": notes,
+        "time_spent_seconds": time_spent_seconds,
+        "submitted_at": submitted_at.astimezone(timezone.utc).isoformat(
+            timespec="microseconds"
+        ),
+        "prev_hash": prev_hash,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_grade(
+    *,
+    grade_id: str,
+    case_id: str,
+    reviewer_id: str,
+    reviewer_role: str,
+    rubric_version: str,
+    scores: RubricScores,
+    notes: str,
+    time_spent_seconds: int,
+    submitted_at: datetime,
+    prev_hash: str,
+) -> Grade:
+    """Construct a Grade with computed row_hash. Factory for callers."""
+    row_hash = compute_row_hash(
+        grade_id=grade_id,
+        case_id=case_id,
+        reviewer_id=reviewer_id,
+        reviewer_role=reviewer_role,
+        rubric_version=rubric_version,
+        scores=scores,
+        notes=notes,
+        time_spent_seconds=time_spent_seconds,
+        submitted_at=submitted_at,
+        prev_hash=prev_hash,
+    )
+    return Grade(
+        grade_id=grade_id,
+        case_id=case_id,
+        reviewer_id=reviewer_id,
+        reviewer_role=reviewer_role,
+        rubric_version=rubric_version,
+        scores=scores,
+        notes=notes,
+        time_spent_seconds=time_spent_seconds,
+        submitted_at=submitted_at,
+        prev_hash=prev_hash,
+        row_hash=row_hash,
+    )
+
+
+def grade_to_row_dict(grade: Grade) -> dict[str, object]:
+    """Flat dict for asyncpg INSERT. scores splatted into columns."""
+    base = asdict(grade)
+    scores = base.pop("scores")
+    base.update(scores)
+    return base

--- a/labeling/settings.py
+++ b/labeling/settings.py
@@ -1,0 +1,52 @@
+"""Labeling service settings. Mirrors env/labeling.env. SKILL.md §11."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class LabelingSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        frozen=True,
+        extra="ignore",
+    )
+
+    service_name: str = "afya-sahihi-labeling"
+    service_port: int = 8085
+
+    # Postgres
+    pg_host: str = "localhost"
+    pg_port: int = 5432
+    pg_database: str = "afya-sahihi"
+    pg_user: str = "afya_sahihi_app"
+    pg_password: str = Field(default="", repr=False)
+    pg_pool_min: int = 2
+    pg_pool_max: int = 8
+    pg_statement_timeout_ms: int = 5000
+
+    # Redis
+    redis_host: str = "localhost"
+    redis_port: int = 6379
+
+    # Queue
+    labeling_queue_key: str = "afya-sahihi:labeling:queue"
+    labeling_queue_max_per_reviewer_per_day: int = 30
+
+    # Rubric
+    rubric_version: str = "v1"
+
+    # Agreement
+    dual_rater_ratio: float = 0.2
+    kappa_alert_threshold: float = 0.7
+
+    # PDF viewer
+    pdf_viewer_base_url: str = "https://afya-sahihi.aku.edu/provenance"
+    pdf_viewer_highlight_bbox: bool = True
+
+    # OIDC (shared with gateway)
+    oidc_issuer_url: str = ""
+    oidc_audience: str = "afya-sahihi"
+    oidc_jwks_uri: str = ""

--- a/labeling/tests/test_app.py
+++ b/labeling/tests/test_app.py
@@ -1,0 +1,150 @@
+"""Tests for the Streamlit shell's pure-python wiring.
+
+We don't import streamlit here — everything that depends on it is
+shaped to accept `st` as a parameter, or sits behind a `_bootstrap`
+call that's only run at Streamlit runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from labeling.app import (
+    RubricSubmission,
+    extract_bearer_token,
+    resolve_reviewer,
+)
+from labeling.auth import UnauthorizedError
+from labeling.jwt_validator import InvalidTokenError
+
+
+# ---- extract_bearer_token ----
+
+
+def test_extract_bearer_token_happy_path() -> None:
+    assert (
+        extract_bearer_token({"Authorization": "Bearer abc.def.ghi"}) == "abc.def.ghi"
+    )
+
+
+def test_extract_bearer_token_lowercase_header() -> None:
+    assert extract_bearer_token({"authorization": "Bearer xyz"}) == "xyz"
+
+
+def test_extract_bearer_token_missing_returns_empty() -> None:
+    assert extract_bearer_token({}) == ""
+
+
+def test_extract_bearer_token_non_bearer_returns_empty() -> None:
+    assert extract_bearer_token({"Authorization": "Basic foo"}) == ""
+
+
+# ---- resolve_reviewer: dev mode (no validator) ----
+
+
+def test_resolve_reviewer_dev_mode_happy_path() -> None:
+    headers = {
+        "X-Forwarded-Claims": json.dumps(
+            {"sub": "u-1", "role": "clinical_reviewer", "name": "Ada"}
+        )
+    }
+    reviewer = resolve_reviewer(headers=headers, validator=None)
+    assert reviewer.user_id == "u-1"
+    assert reviewer.display_name == "Ada"
+
+
+def test_resolve_reviewer_dev_mode_missing_header_refuses() -> None:
+    with pytest.raises(UnauthorizedError, match="X-Forwarded-Claims"):
+        resolve_reviewer(headers={}, validator=None)
+
+
+def test_resolve_reviewer_dev_mode_malformed_json_refuses() -> None:
+    with pytest.raises(UnauthorizedError, match="JSON"):
+        resolve_reviewer(headers={"X-Forwarded-Claims": "not-json{"}, validator=None)
+
+
+def test_resolve_reviewer_dev_mode_non_dict_json_refuses() -> None:
+    with pytest.raises(UnauthorizedError, match="JSON object"):
+        resolve_reviewer(
+            headers={"X-Forwarded-Claims": json.dumps([1, 2, 3])},
+            validator=None,
+        )
+
+
+def test_resolve_reviewer_dev_mode_bad_role_refuses() -> None:
+    headers = {"X-Forwarded-Claims": json.dumps({"sub": "u-1", "role": "admin"})}
+    with pytest.raises(UnauthorizedError, match="role"):
+        resolve_reviewer(headers=headers, validator=None)
+
+
+# ---- resolve_reviewer: production (with validator) ----
+
+
+class FakeValidator:
+    def __init__(self, claims: dict[str, object] | Exception) -> None:
+        self._result = claims
+
+    def validate(self, token: str) -> dict[str, object]:
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def test_resolve_reviewer_prod_mode_happy_path() -> None:
+    validator: Any = FakeValidator(
+        {"sub": "u-2", "role": "senior_clinician", "name": "Wanjiru"}
+    )
+    reviewer = resolve_reviewer(
+        headers={"Authorization": "Bearer validtoken"},
+        validator=validator,
+    )
+    assert reviewer.user_id == "u-2"
+    assert reviewer.role == "senior_clinician"
+
+
+def test_resolve_reviewer_prod_mode_missing_bearer_refuses() -> None:
+    validator: Any = FakeValidator({"sub": "u-1", "role": "clinical_reviewer"})
+    with pytest.raises(UnauthorizedError, match="Bearer"):
+        resolve_reviewer(headers={}, validator=validator)
+
+
+def test_resolve_reviewer_prod_mode_invalid_token_refuses() -> None:
+    validator: Any = FakeValidator(InvalidTokenError("expired"))
+    with pytest.raises(UnauthorizedError, match="invalid token"):
+        resolve_reviewer(
+            headers={"Authorization": "Bearer expiredtoken"},
+            validator=validator,
+        )
+
+
+def test_resolve_reviewer_prod_mode_bad_role_refuses() -> None:
+    validator: Any = FakeValidator({"sub": "u-1", "role": "admin"})
+    with pytest.raises(UnauthorizedError, match="role"):
+        resolve_reviewer(
+            headers={"Authorization": "Bearer token"},
+            validator=validator,
+        )
+
+
+# ---- RubricSubmission shape ----
+
+
+def test_rubric_submission_carries_scrubbed_notes() -> None:
+    # Smoke: just verify the dataclass is importable and holds both fields.
+    from labeling.rubric import RubricScores
+
+    sub = RubricSubmission(
+        scores=RubricScores(
+            accuracy=4,
+            safety=5,
+            guideline_alignment=4,
+            local_appropriateness=3,
+            clarity=4,
+        ),
+        notes="No PHI here.",
+    )
+    assert sub.notes == "No PHI here."
+    assert sub.scores.accuracy == 4

--- a/labeling/tests/test_auth.py
+++ b/labeling/tests/test_auth.py
@@ -1,0 +1,76 @@
+"""Tests for the OIDC role gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from labeling.auth import ALLOWED_ROLES, UnauthorizedError, authorize_reviewer
+
+
+def test_accepts_clinical_reviewer_via_role_claim() -> None:
+    reviewer = authorize_reviewer(
+        {"sub": "u-1", "role": "clinical_reviewer", "name": "Dr Ada"}
+    )
+    assert reviewer.user_id == "u-1"
+    assert reviewer.role == "clinical_reviewer"
+    assert reviewer.display_name == "Dr Ada"
+
+
+def test_accepts_senior_clinician_via_roles_list() -> None:
+    reviewer = authorize_reviewer(
+        {
+            "sub": "u-2",
+            "roles": ["clinical_reviewer", "senior_clinician"],
+            "preferred_username": "aneita@aku.edu",
+        }
+    )
+    assert reviewer.role in ALLOWED_ROLES
+    assert reviewer.display_name == "aneita@aku.edu"
+
+
+def test_accepts_keycloak_realm_access_roles() -> None:
+    reviewer = authorize_reviewer(
+        {
+            "sub": "u-3",
+            "realm_access": {"roles": ["senior_clinician", "admin"]},
+            "name": "Wanjiru",
+        }
+    )
+    assert reviewer.role == "senior_clinician"
+
+
+def test_refuses_missing_sub() -> None:
+    with pytest.raises(UnauthorizedError, match="sub"):
+        authorize_reviewer({"role": "clinical_reviewer"})
+
+
+def test_refuses_empty_sub() -> None:
+    with pytest.raises(UnauthorizedError, match="sub"):
+        authorize_reviewer({"sub": "", "role": "clinical_reviewer"})
+
+
+def test_refuses_non_string_sub() -> None:
+    with pytest.raises(UnauthorizedError, match="sub"):
+        authorize_reviewer({"sub": 42, "role": "clinical_reviewer"})
+
+
+def test_refuses_role_not_in_allow_list() -> None:
+    with pytest.raises(UnauthorizedError, match="role"):
+        authorize_reviewer({"sub": "u-1", "role": "admin"})
+
+
+def test_refuses_no_role_at_all() -> None:
+    with pytest.raises(UnauthorizedError, match="role"):
+        authorize_reviewer({"sub": "u-1"})
+
+
+def test_falls_back_to_sub_when_no_display_name() -> None:
+    reviewer = authorize_reviewer({"sub": "u-1", "role": "clinical_reviewer"})
+    assert reviewer.display_name == "u-1"
+
+
+def test_ignores_non_string_display_name() -> None:
+    reviewer = authorize_reviewer(
+        {"sub": "u-1", "role": "clinical_reviewer", "preferred_username": 42}
+    )
+    assert reviewer.display_name == "u-1"

--- a/labeling/tests/test_daily_kappa.py
+++ b/labeling/tests/test_daily_kappa.py
@@ -1,0 +1,164 @@
+"""Tests for the daily Fleiss kappa job."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from labeling.daily_kappa import run_daily_kappa
+from labeling.rubric import RUBRIC_DIMENSIONS
+
+
+class FakeRepository:
+    def __init__(self, payload: dict[str, dict[str, list[dict[str, int]]]]):
+        self._payload = payload
+        self.last_window: tuple[Any, Any] | None = None
+
+    async def load_agreement_ratings(
+        self, *, window_start: Any, window_end: Any
+    ) -> dict[str, dict[str, list[dict[str, int]]]]:
+        self.last_window = (window_start, window_end)
+        return self._payload
+
+
+def _by_dim(
+    scores_per_reviewer: list[dict[str, int]],
+) -> dict[str, list[dict[str, int]]]:
+    """Expand one reviewer-set-per-case into per-dimension lists."""
+    out: dict[str, list[dict[str, int]]] = {dim: [] for dim in RUBRIC_DIMENSIONS}
+    for reviewer_scores in scores_per_reviewer:
+        for dim in RUBRIC_DIMENSIONS:
+            out[dim].append(
+                {
+                    "reviewer_id": reviewer_scores["reviewer_id"],
+                    "score": reviewer_scores[dim],
+                }
+            )
+    return out
+
+
+async def test_run_daily_kappa_alerts_on_low_agreement() -> None:
+    # Two cases, 2 reviewers each. Reviewers disagree wildly on accuracy
+    # across both cases so agreement < threshold.
+    payload = {
+        "c-1": _by_dim(
+            [
+                {
+                    "reviewer_id": "u-1",
+                    "accuracy": 1,
+                    "safety": 3,
+                    "guideline_alignment": 3,
+                    "local_appropriateness": 3,
+                    "clarity": 3,
+                },
+                {
+                    "reviewer_id": "u-2",
+                    "accuracy": 5,
+                    "safety": 3,
+                    "guideline_alignment": 3,
+                    "local_appropriateness": 3,
+                    "clarity": 3,
+                },
+            ]
+        ),
+        "c-2": _by_dim(
+            [
+                {
+                    "reviewer_id": "u-1",
+                    "accuracy": 2,
+                    "safety": 3,
+                    "guideline_alignment": 3,
+                    "local_appropriateness": 3,
+                    "clarity": 3,
+                },
+                {
+                    "reviewer_id": "u-3",
+                    "accuracy": 4,
+                    "safety": 3,
+                    "guideline_alignment": 3,
+                    "local_appropriateness": 3,
+                    "clarity": 3,
+                },
+            ]
+        ),
+    }
+    repo: Any = FakeRepository(payload)
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    report = await run_daily_kappa(repository=repo, now=now, alert_threshold=0.7)
+    assert report.dimension_n_items["accuracy"] == 2
+    assert any("accuracy" in alert for alert in report.alerts)
+    # Other dims have all 3s across both raters → degenerate (nan).
+    assert math.isnan(report.dimension_kappa["safety"])
+    # Window spans exactly 24h ending at `now`.
+    assert (report.window_end - report.window_start).total_seconds() == 86400
+
+
+async def test_run_daily_kappa_skips_single_rated_cases() -> None:
+    payload = {
+        "c-1": _by_dim(
+            [
+                {
+                    "reviewer_id": "u-1",
+                    "accuracy": 5,
+                    "safety": 5,
+                    "guideline_alignment": 5,
+                    "local_appropriateness": 5,
+                    "clarity": 5,
+                },
+            ]
+        ),
+    }
+    repo: Any = FakeRepository(payload)
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    report = await run_daily_kappa(repository=repo, now=now, alert_threshold=0.7)
+    # No dual-rated cases → every dim is nan, no alerts.
+    for dim in RUBRIC_DIMENSIONS:
+        assert math.isnan(report.dimension_kappa[dim])
+        assert report.dimension_n_items[dim] == 0
+    assert report.alerts == ()
+
+
+async def test_run_daily_kappa_no_alert_when_kappa_above_threshold() -> None:
+    # 4 cases, 2 reviewers; all raters agree on every case for accuracy.
+    # Other dims mixed — only accuracy should have kappa == 1.
+    payload = {}
+    for i, acc in enumerate((1, 2, 3, 4)):
+        payload[f"c-{i}"] = _by_dim(
+            [
+                {
+                    "reviewer_id": "u-1",
+                    "accuracy": acc,
+                    "safety": 3,
+                    "guideline_alignment": 3,
+                    "local_appropriateness": 3,
+                    "clarity": 3,
+                },
+                {
+                    "reviewer_id": "u-2",
+                    "accuracy": acc,
+                    "safety": 3,
+                    "guideline_alignment": 3,
+                    "local_appropriateness": 3,
+                    "clarity": 3,
+                },
+            ]
+        )
+    repo: Any = FakeRepository(payload)
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    report = await run_daily_kappa(repository=repo, now=now, alert_threshold=0.7)
+    # Accuracy: perfect agreement, non-degenerate distribution → kappa == 1.
+    assert report.dimension_kappa["accuracy"] == pytest.approx(1.0)
+    assert "accuracy" not in " ".join(report.alerts)
+
+
+async def test_run_daily_kappa_rejects_bad_threshold() -> None:
+    repo: Any = FakeRepository({})
+    with pytest.raises(ValueError, match="threshold"):
+        await run_daily_kappa(
+            repository=repo,
+            now=datetime(2026, 4, 18, tzinfo=timezone.utc),
+            alert_threshold=2.0,
+        )

--- a/labeling/tests/test_jwt_validator.py
+++ b/labeling/tests/test_jwt_validator.py
@@ -1,0 +1,129 @@
+"""Tests for the OIDC JWT validator.
+
+We craft a real RSA-signed JWT with PyJWT (dev dep via labeling[ui])
+and feed it through the validator. When PyJWT is not installed we skip
+(tests still cover the error branch via a fake jwks client).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from labeling.jwt_validator import InvalidTokenError, OidcValidator
+
+jwt = pytest.importorskip("jwt")
+
+
+def _gen_keypair() -> tuple[Any, Any]:
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return priv, priv.public_key()
+
+
+class FakeJwksClient:
+    def __init__(self, key: Any) -> None:
+        self._key = key
+
+    def get_signing_key_from_jwt(self, token: str) -> Any:
+        class _K:
+            pass
+
+        k = _K()
+        k.key = self._key
+        return k
+
+
+def test_validate_accepts_correctly_signed_token() -> None:
+    priv, pub = _gen_keypair()
+    token = jwt.encode(
+        {
+            "sub": "u-1",
+            "aud": "afya-sahihi",
+            "iss": "https://idp.aku.edu",
+            "role": "clinical_reviewer",
+        },
+        priv,
+        algorithm="RS256",
+    )
+    validator = OidcValidator(
+        jwks_client=FakeJwksClient(pub),
+        issuer="https://idp.aku.edu",
+        audience="afya-sahihi",
+    )
+    claims = validator.validate(token)
+    assert claims["sub"] == "u-1"
+    assert claims["role"] == "clinical_reviewer"
+
+
+def test_validate_rejects_empty_token() -> None:
+    validator = OidcValidator(
+        jwks_client=FakeJwksClient(None),
+        issuer="https://idp.aku.edu",
+        audience="afya-sahihi",
+    )
+    with pytest.raises(InvalidTokenError, match="empty"):
+        validator.validate("")
+
+
+def test_validate_rejects_wrong_audience() -> None:
+    priv, pub = _gen_keypair()
+    token = jwt.encode(
+        {
+            "sub": "u-1",
+            "aud": "wrong-audience",
+            "iss": "https://idp.aku.edu",
+        },
+        priv,
+        algorithm="RS256",
+    )
+    validator = OidcValidator(
+        jwks_client=FakeJwksClient(pub),
+        issuer="https://idp.aku.edu",
+        audience="afya-sahihi",
+    )
+    with pytest.raises(InvalidTokenError):
+        validator.validate(token)
+
+
+def test_validate_rejects_wrong_issuer() -> None:
+    priv, pub = _gen_keypair()
+    token = jwt.encode(
+        {
+            "sub": "u-1",
+            "aud": "afya-sahihi",
+            "iss": "https://attacker.example.com",
+        },
+        priv,
+        algorithm="RS256",
+    )
+    validator = OidcValidator(
+        jwks_client=FakeJwksClient(pub),
+        issuer="https://idp.aku.edu",
+        audience="afya-sahihi",
+    )
+    with pytest.raises(InvalidTokenError):
+        validator.validate(token)
+
+
+def test_validate_rejects_wrong_signing_key() -> None:
+    priv, _ = _gen_keypair()
+    _, wrong_pub = _gen_keypair()
+    token = jwt.encode(
+        {
+            "sub": "u-1",
+            "aud": "afya-sahihi",
+            "iss": "https://idp.aku.edu",
+        },
+        priv,
+        algorithm="RS256",
+    )
+    validator = OidcValidator(
+        jwks_client=FakeJwksClient(wrong_pub),
+        issuer="https://idp.aku.edu",
+        audience="afya-sahihi",
+    )
+    with pytest.raises(InvalidTokenError):
+        validator.validate(token)

--- a/labeling/tests/test_kappa.py
+++ b/labeling/tests/test_kappa.py
@@ -1,0 +1,119 @@
+"""Tests for Fleiss kappa.
+
+Reference values for the canonical example from the Fleiss (1971) paper
+and a few edge cases."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from labeling.kappa import build_counts_matrix, fleiss_kappa
+
+
+def test_perfect_agreement_gives_kappa_one() -> None:
+    # 4 items, 3 raters, 2 categories, everyone always picks category 0.
+    # Above chance (chance = 1.0 since p_cat[0] = 1) → kappa is nan
+    # (denominator 0). Swap one rater to make chance < 1 but agreement
+    # still perfect per-item for the remaining rows.
+    counts = [
+        [3, 0],
+        [0, 3],
+        [3, 0],
+        [0, 3],
+    ]
+    result = fleiss_kappa(item_rater_category_counts=counts)
+    assert result.kappa == pytest.approx(1.0, abs=1e-9)
+    assert result.n_items == 4
+    assert result.n_raters == 3
+    assert result.n_categories == 2
+
+
+def test_random_agreement_gives_kappa_near_zero() -> None:
+    # Split uniformly across 2 categories → agreement matches chance.
+    # n=4 raters, 100 items, 50/50 distribution per item on avg.
+    counts = [[2, 2]] * 100
+    result = fleiss_kappa(item_rater_category_counts=counts)
+    # P_i = (4 + 4 - 4) / (4*3) = 4/12 = 1/3. P_e = 0.5² + 0.5² = 0.5.
+    # kappa = (1/3 - 0.5) / (1 - 0.5) = -1/3.
+    assert result.kappa == pytest.approx(-1 / 3, abs=1e-9)
+
+
+def test_fleiss_canonical_example() -> None:
+    # Fleiss 1971, table 1: 30 psychiatric diagnoses, 6 raters, 5
+    # categories. The reported kappa is 0.430; we verify against a
+    # smaller trimmed version so the test stays readable.
+    # 4 items, 3 raters, 3 categories
+    counts = [
+        [3, 0, 0],  # unanimous on cat 0
+        [2, 1, 0],  # majority cat 0
+        [0, 3, 0],  # unanimous on cat 1
+        [0, 2, 1],  # majority cat 1
+    ]
+    result = fleiss_kappa(item_rater_category_counts=counts)
+    # P_i: (9-3)/6=1, (4+1-3)/6=1/3, (9-3)/6=1, (4+1-3)/6=1/3
+    # mean = (1+1/3+1+1/3)/4 = 2/3
+    # column sums: 5, 6, 1; totals 12; p_cat = [5/12, 6/12, 1/12]
+    # P_e = 25/144 + 36/144 + 1/144 = 62/144
+    # kappa = (2/3 - 62/144) / (1 - 62/144)
+    expected = (2 / 3 - 62 / 144) / (1 - 62 / 144)
+    assert result.kappa == pytest.approx(expected, abs=1e-9)
+    assert result.p_mean_agreement == pytest.approx(2 / 3, abs=1e-9)
+
+
+def test_empty_input_raises() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        fleiss_kappa(item_rater_category_counts=[])
+
+
+def test_inconsistent_rater_counts_raise() -> None:
+    with pytest.raises(ValueError, match="raters"):
+        fleiss_kappa(
+            item_rater_category_counts=[
+                [3, 0],
+                [1, 1],  # only 2 raters; first row had 3
+            ]
+        )
+
+
+def test_inconsistent_category_counts_raise() -> None:
+    with pytest.raises(ValueError, match="categories"):
+        fleiss_kappa(
+            item_rater_category_counts=[
+                [1, 1, 1],
+                [2, 1],
+            ]
+        )
+
+
+def test_negative_counts_raise() -> None:
+    with pytest.raises(ValueError, match="negative"):
+        fleiss_kappa(item_rater_category_counts=[[3, -1], [1, 1]])
+
+
+def test_degenerate_single_category_returns_nan() -> None:
+    # All raters agreed on a single category across all items. P_e = 1,
+    # denom = 0, kappa undefined.
+    counts = [[3, 0], [3, 0], [3, 0]]
+    result = fleiss_kappa(item_rater_category_counts=counts)
+    assert math.isnan(result.kappa)
+
+
+def test_build_counts_matrix_roundtrips() -> None:
+    ratings = [[0, 0, 1], [2, 2, 2], [1, 0, 0]]
+    counts = build_counts_matrix(ratings_per_item=ratings, n_categories=3)
+    assert counts == [
+        [2, 1, 0],
+        [0, 0, 3],
+        [2, 1, 0],
+    ]
+
+
+def test_build_counts_matrix_rejects_out_of_range_label() -> None:
+    with pytest.raises(ValueError, match="outside"):
+        build_counts_matrix(ratings_per_item=[[0, 3]], n_categories=3)
+
+
+def test_build_counts_matrix_empty_returns_empty() -> None:
+    assert build_counts_matrix(ratings_per_item=[], n_categories=3) == []

--- a/labeling/tests/test_pdf_viewer.py
+++ b/labeling/tests/test_pdf_viewer.py
@@ -1,0 +1,94 @@
+"""Tests for the PDF viewer URL builder."""
+
+from __future__ import annotations
+
+import pytest
+
+from labeling.pdf_viewer import BoundingBox, build_viewer_url
+
+
+def test_build_viewer_url_no_bbox() -> None:
+    url = build_viewer_url(
+        base_url="https://x.aku.edu/provenance",
+        document_id="doc-1",
+        bbox=None,
+        highlight=True,
+    )
+    assert url == "https://x.aku.edu/provenance/doc-1"
+
+
+def test_build_viewer_url_with_bbox_and_highlight() -> None:
+    bbox = BoundingBox(page=3, x0=0.1, y0=0.2, x1=0.5, y1=0.4)
+    url = build_viewer_url(
+        base_url="https://x.aku.edu/provenance",
+        document_id="doc-1",
+        bbox=bbox,
+        highlight=True,
+    )
+    assert url == (
+        "https://x.aku.edu/provenance/doc-1?"
+        "page=3&bbox=0.1000%2C0.2000%2C0.5000%2C0.4000"
+    )
+
+
+def test_build_viewer_url_with_bbox_no_highlight_still_includes_page() -> None:
+    bbox = BoundingBox(page=2, x0=0.0, y0=0.0, x1=0.5, y1=0.5)
+    url = build_viewer_url(
+        base_url="https://x.aku.edu/provenance",
+        document_id="doc-1",
+        bbox=bbox,
+        highlight=False,
+    )
+    assert url == "https://x.aku.edu/provenance/doc-1?page=2"
+
+
+def test_build_viewer_url_strips_trailing_slash() -> None:
+    url = build_viewer_url(
+        base_url="https://x.aku.edu/provenance/",
+        document_id="doc-1",
+        bbox=None,
+        highlight=True,
+    )
+    assert url == "https://x.aku.edu/provenance/doc-1"
+
+
+def test_build_viewer_url_encodes_document_id() -> None:
+    url = build_viewer_url(
+        base_url="https://x.aku.edu/provenance",
+        document_id="doc 1/with?chars",
+        bbox=None,
+        highlight=True,
+    )
+    assert url == "https://x.aku.edu/provenance/doc%201%2Fwith%3Fchars"
+
+
+def test_build_viewer_url_rejects_empty_base() -> None:
+    with pytest.raises(ValueError, match="base_url"):
+        build_viewer_url(
+            base_url="",
+            document_id="doc-1",
+            bbox=None,
+            highlight=True,
+        )
+
+
+# ---- BoundingBox validation ----
+
+
+def test_bbox_rejects_non_positive_page() -> None:
+    with pytest.raises(ValueError, match="page"):
+        BoundingBox(page=0, x0=0.1, y0=0.2, x1=0.5, y1=0.4)
+
+
+def test_bbox_rejects_out_of_range_coord() -> None:
+    with pytest.raises(ValueError, match="outside"):
+        BoundingBox(page=1, x0=-0.1, y0=0.0, x1=0.5, y1=0.4)
+    with pytest.raises(ValueError, match="outside"):
+        BoundingBox(page=1, x0=0.0, y0=0.0, x1=1.5, y1=0.4)
+
+
+def test_bbox_rejects_inverted_coords() -> None:
+    with pytest.raises(ValueError, match="x0 < x1"):
+        BoundingBox(page=1, x0=0.5, y0=0.1, x1=0.2, y1=0.4)
+    with pytest.raises(ValueError, match="x0 < x1"):
+        BoundingBox(page=1, x0=0.1, y0=0.5, x1=0.2, y1=0.4)

--- a/labeling/tests/test_phi.py
+++ b/labeling/tests/test_phi.py
@@ -1,0 +1,55 @@
+"""Tests for the labeling PHI scrubber."""
+
+from __future__ import annotations
+
+from labeling.phi import REPLACEMENT, scrub
+
+
+def test_scrub_redacts_kenyan_national_id() -> None:
+    result = scrub("ID is 12345678 in the records.")
+    assert REPLACEMENT in result.scrubbed
+    assert "12345678" not in result.scrubbed
+    assert "national_id" in result.hits
+    assert result.failed is False
+
+
+def test_scrub_redacts_phone_with_country_code() -> None:
+    result = scrub("Call +254 712 345 678")
+    assert "712" not in result.scrubbed
+    assert "phone" in result.hits
+
+
+def test_scrub_redacts_local_phone_format() -> None:
+    result = scrub("Call 0712 345 678")
+    assert "0712" not in result.scrubbed
+
+
+def test_scrub_redacts_email() -> None:
+    result = scrub("Contact: dr.smith@aku.edu for follow-up.")
+    assert "dr.smith@aku.edu" not in result.scrubbed
+    assert "email" in result.hits
+
+
+def test_scrub_redacts_mrn() -> None:
+    result = scrub("Patient MRN ABC-123456")
+    assert "ABC-123456" not in result.scrubbed
+
+
+def test_scrub_clean_text_unchanged() -> None:
+    result = scrub("The guideline recommends aspirin 300mg stat.")
+    assert result.scrubbed == "The guideline recommends aspirin 300mg stat."
+    assert result.hits == ()
+    assert result.failed is False
+
+
+def test_scrub_non_string_fails_closed() -> None:
+    result = scrub(None)  # type: ignore[arg-type]
+    assert result.failed is True
+    assert result.scrubbed == ""
+
+
+def test_scrub_empty_string_succeeds() -> None:
+    result = scrub("")
+    assert result.scrubbed == ""
+    assert result.failed is False
+    assert result.hits == ()

--- a/labeling/tests/test_queue.py
+++ b/labeling/tests/test_queue.py
@@ -1,0 +1,159 @@
+"""Tests for the Redis-backed queue. Uses an in-memory fake."""
+
+from __future__ import annotations
+
+import pytest
+
+from labeling.queue import QueueKeys, ReviewerCaseQueue
+
+
+class FakeRedis:
+    """Minimal in-memory Redis stand-in covering the methods used."""
+
+    def __init__(self) -> None:
+        self._lists: dict[str, list[str]] = {}
+        self._sets: dict[str, set[str]] = {}
+
+    async def lrange(self, key: str, start: int, end: int) -> list[bytes]:
+        items = self._lists.get(key, [])
+        stop = len(items) if end == -1 else end + 1
+        return [item.encode("utf-8") for item in items[start:stop]]
+
+    async def lrem(self, key: str, count: int, value: str) -> int:
+        items = self._lists.get(key, [])
+        removed = 0
+        target = count if count > 0 else len(items)
+        new_items: list[str] = []
+        for item in items:
+            if item == value and removed < target:
+                removed += 1
+                continue
+            new_items.append(item)
+        self._lists[key] = new_items
+        return removed
+
+    async def rpush(self, key: str, *values: str) -> int:
+        bucket = self._lists.setdefault(key, [])
+        bucket.extend(values)
+        return len(bucket)
+
+    async def sadd(self, key: str, *values: str) -> int:
+        bucket = self._sets.setdefault(key, set())
+        added = 0
+        for v in values:
+            if v not in bucket:
+                bucket.add(v)
+                added += 1
+        return added
+
+    async def smembers(self, key: str) -> set[bytes]:
+        return {v.encode("utf-8") for v in self._sets.get(key, set())}
+
+    async def scard(self, key: str) -> int:
+        return len(self._sets.get(key, set()))
+
+
+@pytest.fixture
+def keys() -> QueueKeys:
+    return QueueKeys.for_reviewer(
+        base_key="test:labeling:q",
+        reviewer_id="u-1",
+        iso_week="2026-W16",
+    )
+
+
+@pytest.fixture
+async def queue(keys: QueueKeys) -> ReviewerCaseQueue:
+    redis = FakeRedis()
+    # Seed pending cases for the reviewer.
+    await redis.rpush(keys.pending, "case-1", "case-2", "case-3")
+    return ReviewerCaseQueue(redis=redis, keys=keys)
+
+
+async def test_queue_keys_namespacing() -> None:
+    keys = QueueKeys.for_reviewer(
+        base_key="afya:lbl",
+        reviewer_id="u-42",
+        iso_week="2026-W16",
+    )
+    assert keys.pending == "afya:lbl:u-42:2026-W16:pending"
+    assert keys.in_flight == "afya:lbl:u-42:2026-W16:in_flight"
+    assert keys.completed == "afya:lbl:u-42:2026-W16:completed"
+
+
+async def test_list_pending_returns_cases(queue: ReviewerCaseQueue) -> None:
+    pending = await queue.list_pending()
+    assert pending == ["case-1", "case-2", "case-3"]
+
+
+async def test_reserve_next_moves_head_to_in_flight(
+    queue: ReviewerCaseQueue,
+) -> None:
+    first = await queue.reserve_next()
+    assert first == "case-1"
+    remaining = await queue.list_pending()
+    assert remaining == ["case-2", "case-3"]
+
+
+async def test_reserve_next_on_empty_queue_returns_none(keys: QueueKeys) -> None:
+    q = ReviewerCaseQueue(redis=FakeRedis(), keys=keys)
+    assert await q.reserve_next() is None
+
+
+async def test_complete_moves_in_flight_to_completed_set(
+    queue: ReviewerCaseQueue,
+) -> None:
+    await queue.reserve_next()  # reserves case-1
+    returned = await queue.complete("case-1")
+    assert returned is True
+    assert await queue.completed_count() == 1
+
+
+async def test_complete_of_unreserved_returns_false(
+    queue: ReviewerCaseQueue,
+) -> None:
+    returned = await queue.complete("case-99")
+    assert returned is False
+    # Still recorded as completed in the set (idempotent analytics).
+    assert await queue.completed_count() == 1
+
+
+async def test_release_returns_case_to_pending(queue: ReviewerCaseQueue) -> None:
+    await queue.reserve_next()  # reserves case-1
+    released = await queue.release("case-1")
+    assert released is True
+    pending = await queue.list_pending()
+    # case-1 returned to tail, ordering: case-2, case-3, case-1.
+    assert pending == ["case-2", "case-3", "case-1"]
+
+
+async def test_release_of_unreserved_returns_false(
+    queue: ReviewerCaseQueue,
+) -> None:
+    released = await queue.release("case-never-reserved")
+    assert released is False
+
+
+async def test_reserve_next_race_returns_none_on_lost_lrem(
+    keys: QueueKeys,
+) -> None:
+    # Fake a Redis where LREM reports 0 (another reviewer grabbed it).
+    class RacyFake(FakeRedis):
+        async def lrem(self, key: str, count: int, value: str) -> int:
+            # Simulate the other reviewer winning: pretend nothing was removed.
+            return 0
+
+    r = RacyFake()
+    await r.rpush(keys.pending, "case-1")
+    q = ReviewerCaseQueue(redis=r, keys=keys)
+    assert await q.reserve_next() is None
+
+
+async def test_complete_rejects_empty_case_id(queue: ReviewerCaseQueue) -> None:
+    with pytest.raises(ValueError, match="case_id"):
+        await queue.complete("")
+
+
+async def test_release_rejects_empty_case_id(queue: ReviewerCaseQueue) -> None:
+    with pytest.raises(ValueError, match="case_id"):
+        await queue.release("")

--- a/labeling/tests/test_repository.py
+++ b/labeling/tests/test_repository.py
@@ -1,4 +1,4 @@
-"""Tests for GradeRepository. Uses a fake asyncpg pool."""
+"""Tests for GradeRepository. Uses a fake asyncpg pool + transaction."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 
 from labeling.repository import GradeRepository
-from labeling.rubric import RubricScores, build_grade
+from labeling.rubric import RubricScores
 
 
 class FakeConnection:
@@ -17,6 +17,7 @@ class FakeConnection:
         self.executed: list[tuple[str, tuple[Any, ...]]] = []
         self.fetchval_result: Any = None
         self.fetch_result: list[dict[str, Any]] = []
+        self.transaction_entered: int = 0
 
     async def execute(self, query: str, *args: Any) -> Any:
         self.executed.append((query, args))
@@ -29,6 +30,14 @@ class FakeConnection:
     async def fetch(self, query: str, *args: Any) -> list[Any]:
         self.executed.append((query, args))
         return self.fetch_result
+
+    def transaction(self, **_: Any) -> Any:
+        @asynccontextmanager
+        async def _cm() -> Any:
+            self.transaction_entered += 1
+            yield
+
+        return _cm()
 
 
 class FakePool:
@@ -55,47 +64,47 @@ def repo(conn: FakeConnection) -> GradeRepository:
     return GradeRepository(pool=FakePool(conn), statement_timeout_ms=1234)
 
 
-def _grade() -> Any:
-    return build_grade(
+def _scores() -> RubricScores:
+    return RubricScores(
+        accuracy=4,
+        safety=5,
+        guideline_alignment=4,
+        local_appropriateness=3,
+        clarity=4,
+    )
+
+
+async def test_insert_next_grade_runs_inside_transaction(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    await repo.insert_next_grade(
         grade_id="g-1",
         case_id="c-1",
         reviewer_id="u-1",
         reviewer_role="clinical_reviewer",
         rubric_version="v1",
-        scores=RubricScores(
-            accuracy=4,
-            safety=5,
-            guideline_alignment=4,
-            local_appropriateness=3,
-            clarity=4,
-        ),
+        scores=_scores(),
         notes="ok",
         time_spent_seconds=90,
         submitted_at=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
-        prev_hash="",
     )
+    assert conn.transaction_entered == 1
 
 
-async def test_latest_row_hash_empty_returns_empty_string(
+async def test_insert_next_grade_sets_statement_timeout(
     repo: GradeRepository, conn: FakeConnection
 ) -> None:
-    conn.fetchval_result = None
-    result = await repo.latest_row_hash(reviewer_id="u-1")
-    assert result == ""
-
-
-async def test_latest_row_hash_returns_value(
-    repo: GradeRepository, conn: FakeConnection
-) -> None:
-    conn.fetchval_result = "abcd1234"
-    result = await repo.latest_row_hash(reviewer_id="u-1")
-    assert result == "abcd1234"
-
-
-async def test_insert_grade_sets_statement_timeout(
-    repo: GradeRepository, conn: FakeConnection
-) -> None:
-    await repo.insert_grade(_grade())
+    await repo.insert_next_grade(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="ok",
+        time_spent_seconds=90,
+        submitted_at=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+    )
     timeout_calls = [
         q for q, _ in conn.executed if q.startswith("SET LOCAL statement_timeout")
     ]
@@ -103,33 +112,82 @@ async def test_insert_grade_sets_statement_timeout(
     assert "1234ms" in timeout_calls[0]
 
 
-async def test_insert_grade_passes_expected_columns(
+async def test_insert_next_grade_takes_advisory_lock(
     repo: GradeRepository, conn: FakeConnection
 ) -> None:
-    grade = _grade()
-    await repo.insert_grade(grade)
-    # The INSERT is the second execute call (first is SET LOCAL).
-    insert_call = [q for q, _ in conn.executed if q.strip().startswith("INSERT")]
-    assert len(insert_call) == 1
+    await repo.insert_next_grade(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-42",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="ok",
+        time_spent_seconds=90,
+        submitted_at=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    lock_calls = [
+        (q, args) for q, args in conn.executed if "pg_advisory_xact_lock" in q
+    ]
+    assert len(lock_calls) == 1
+    assert lock_calls[0][1] == ("u-42",)
 
-    # Find the args for the INSERT
-    for q, args in conn.executed:
-        if q.strip().startswith("INSERT"):
-            assert args[0] == "g-1"  # grade_id
-            assert args[1] == "c-1"  # case_id
-            assert args[2] == "u-1"  # reviewer_id
-            assert args[3] == "clinical_reviewer"  # reviewer_role
-            assert args[4] == "v1"  # rubric_version
-            assert args[5] == 4  # accuracy
-            assert args[6] == 5  # safety
-            assert args[7] == 4  # guideline_alignment
-            assert args[8] == 3  # local_appropriateness
-            assert args[9] == 4  # clarity
-            assert args[10] == "ok"  # notes
-            assert args[11] == 90  # time_spent_seconds
-            assert args[13] == ""  # prev_hash
-            assert args[14] == grade.row_hash  # row_hash
-            break
+
+async def test_insert_next_grade_chains_on_prev_hash(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    conn.fetchval_result = "previoushash123"
+    row_hash = await repo.insert_next_grade(
+        grade_id="g-2",
+        case_id="c-2",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="ok",
+        time_spent_seconds=90,
+        submitted_at=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert row_hash
+    assert len(row_hash) == 64  # SHA-256 hex
+
+    # The INSERT args include prev_hash=fetchval_result
+    insert_args = next(
+        args for q, args in conn.executed if q.strip().startswith("INSERT")
+    )
+    assert insert_args[13] == "previoushash123"  # prev_hash
+    assert insert_args[14] == row_hash
+
+
+async def test_insert_next_grade_genesis_uses_empty_prev_hash(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    conn.fetchval_result = None
+    await repo.insert_next_grade(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="ok",
+        time_spent_seconds=90,
+        submitted_at=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    insert_args = next(
+        args for q, args in conn.executed if q.strip().startswith("INSERT")
+    )
+    assert insert_args[13] == ""  # prev_hash
+
+
+async def test_load_agreement_runs_inside_transaction(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    conn.fetch_result = []
+    window_start = datetime(2026, 4, 17, 0, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 4, 18, 0, 0, 0, tzinfo=timezone.utc)
+    await repo.load_agreement_ratings(window_start=window_start, window_end=window_end)
+    assert conn.transaction_entered == 1
 
 
 async def test_load_agreement_groups_ratings_by_case_and_dimension(

--- a/labeling/tests/test_repository.py
+++ b/labeling/tests/test_repository.py
@@ -1,0 +1,176 @@
+"""Tests for GradeRepository. Uses a fake asyncpg pool."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from labeling.repository import GradeRepository
+from labeling.rubric import RubricScores, build_grade
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.fetchval_result: Any = None
+        self.fetch_result: list[dict[str, Any]] = []
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        self.executed.append((query, args))
+        return "OK"
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.executed.append((query, args))
+        return self.fetchval_result
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        self.executed.append((query, args))
+        return self.fetch_result
+
+
+class FakePool:
+    def __init__(self, conn: FakeConnection) -> None:
+        self._conn = conn
+
+    def acquire(self) -> Any:
+        conn = self._conn
+
+        @asynccontextmanager
+        async def _cm() -> Any:
+            yield conn
+
+        return _cm()
+
+
+@pytest.fixture
+def conn() -> FakeConnection:
+    return FakeConnection()
+
+
+@pytest.fixture
+def repo(conn: FakeConnection) -> GradeRepository:
+    return GradeRepository(pool=FakePool(conn), statement_timeout_ms=1234)
+
+
+def _grade() -> Any:
+    return build_grade(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=RubricScores(
+            accuracy=4,
+            safety=5,
+            guideline_alignment=4,
+            local_appropriateness=3,
+            clarity=4,
+        ),
+        notes="ok",
+        time_spent_seconds=90,
+        submitted_at=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+        prev_hash="",
+    )
+
+
+async def test_latest_row_hash_empty_returns_empty_string(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    conn.fetchval_result = None
+    result = await repo.latest_row_hash(reviewer_id="u-1")
+    assert result == ""
+
+
+async def test_latest_row_hash_returns_value(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    conn.fetchval_result = "abcd1234"
+    result = await repo.latest_row_hash(reviewer_id="u-1")
+    assert result == "abcd1234"
+
+
+async def test_insert_grade_sets_statement_timeout(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    await repo.insert_grade(_grade())
+    timeout_calls = [
+        q for q, _ in conn.executed if q.startswith("SET LOCAL statement_timeout")
+    ]
+    assert len(timeout_calls) == 1
+    assert "1234ms" in timeout_calls[0]
+
+
+async def test_insert_grade_passes_expected_columns(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    grade = _grade()
+    await repo.insert_grade(grade)
+    # The INSERT is the second execute call (first is SET LOCAL).
+    insert_call = [q for q, _ in conn.executed if q.strip().startswith("INSERT")]
+    assert len(insert_call) == 1
+
+    # Find the args for the INSERT
+    for q, args in conn.executed:
+        if q.strip().startswith("INSERT"):
+            assert args[0] == "g-1"  # grade_id
+            assert args[1] == "c-1"  # case_id
+            assert args[2] == "u-1"  # reviewer_id
+            assert args[3] == "clinical_reviewer"  # reviewer_role
+            assert args[4] == "v1"  # rubric_version
+            assert args[5] == 4  # accuracy
+            assert args[6] == 5  # safety
+            assert args[7] == 4  # guideline_alignment
+            assert args[8] == 3  # local_appropriateness
+            assert args[9] == 4  # clarity
+            assert args[10] == "ok"  # notes
+            assert args[11] == 90  # time_spent_seconds
+            assert args[13] == ""  # prev_hash
+            assert args[14] == grade.row_hash  # row_hash
+            break
+
+
+async def test_load_agreement_groups_ratings_by_case_and_dimension(
+    repo: GradeRepository, conn: FakeConnection
+) -> None:
+    conn.fetch_result = [
+        {
+            "case_id": "c-1",
+            "reviewer_id": "u-1",
+            "accuracy": 5,
+            "safety": 4,
+            "guideline_alignment": 5,
+            "local_appropriateness": 4,
+            "clarity": 5,
+        },
+        {
+            "case_id": "c-1",
+            "reviewer_id": "u-2",
+            "accuracy": 4,
+            "safety": 4,
+            "guideline_alignment": 5,
+            "local_appropriateness": 3,
+            "clarity": 4,
+        },
+        {
+            "case_id": "c-2",
+            "reviewer_id": "u-1",
+            "accuracy": 2,
+            "safety": 3,
+            "guideline_alignment": 2,
+            "local_appropriateness": 3,
+            "clarity": 3,
+        },
+    ]
+    window_start = datetime(2026, 4, 17, 0, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 4, 18, 0, 0, 0, tzinfo=timezone.utc)
+    result = await repo.load_agreement_ratings(
+        window_start=window_start, window_end=window_end
+    )
+    assert set(result.keys()) == {"c-1", "c-2"}
+    assert len(result["c-1"]["accuracy"]) == 2
+    assert result["c-1"]["accuracy"][0] == {"reviewer_id": "u-1", "score": 5}
+    assert result["c-1"]["accuracy"][1] == {"reviewer_id": "u-2", "score": 4}
+    assert len(result["c-2"]["safety"]) == 1

--- a/labeling/tests/test_rubric.py
+++ b/labeling/tests/test_rubric.py
@@ -1,0 +1,284 @@
+"""Tests for rubric value objects and row_hash chain."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from labeling.rubric import (
+    RUBRIC_DIMENSIONS,
+    SCALE_MAX,
+    SCALE_MIN,
+    RubricScores,
+    build_grade,
+    compute_row_hash,
+    grade_to_row_dict,
+)
+
+
+def _fixed_now() -> datetime:
+    return datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---- RubricScores ----
+
+
+def test_rubric_scores_accepts_valid_range() -> None:
+    scores = RubricScores(
+        accuracy=1,
+        safety=5,
+        guideline_alignment=3,
+        local_appropriateness=4,
+        clarity=2,
+    )
+    assert scores.accuracy == 1
+    assert scores.safety == 5
+
+
+def test_rubric_scores_rejects_below_min() -> None:
+    with pytest.raises(ValueError, match="accuracy=0 out of range"):
+        RubricScores(
+            accuracy=0,
+            safety=3,
+            guideline_alignment=3,
+            local_appropriateness=3,
+            clarity=3,
+        )
+
+
+def test_rubric_scores_rejects_above_max() -> None:
+    with pytest.raises(ValueError, match="safety=6 out of range"):
+        RubricScores(
+            accuracy=3,
+            safety=6,
+            guideline_alignment=3,
+            local_appropriateness=3,
+            clarity=3,
+        )
+
+
+def test_rubric_scores_rejects_non_int() -> None:
+    with pytest.raises(ValueError, match="accuracy must be int"):
+        RubricScores(
+            accuracy=3.5,  # type: ignore[arg-type]
+            safety=3,
+            guideline_alignment=3,
+            local_appropriateness=3,
+            clarity=3,
+        )
+
+
+def test_rubric_scores_rejects_bool() -> None:
+    # bool is an int subclass in Python; we reject it explicitly so
+    # True/False don't silently become 1/0.
+    with pytest.raises(ValueError, match="accuracy must be int"):
+        RubricScores(
+            accuracy=True,  # type: ignore[arg-type]
+            safety=3,
+            guideline_alignment=3,
+            local_appropriateness=3,
+            clarity=3,
+        )
+
+
+def test_rubric_dimensions_match_env_spec() -> None:
+    # env/labeling.env declares these exact five, in this order.
+    assert RUBRIC_DIMENSIONS == (
+        "accuracy",
+        "safety",
+        "guideline_alignment",
+        "local_appropriateness",
+        "clarity",
+    )
+
+
+def test_scale_bounds() -> None:
+    assert SCALE_MIN == 1
+    assert SCALE_MAX == 5
+
+
+# ---- row_hash ----
+
+
+def _scores() -> RubricScores:
+    return RubricScores(
+        accuracy=4,
+        safety=5,
+        guideline_alignment=4,
+        local_appropriateness=3,
+        clarity=4,
+    )
+
+
+def test_row_hash_is_deterministic() -> None:
+    kwargs = dict(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="",
+        time_spent_seconds=90,
+        submitted_at=_fixed_now(),
+        prev_hash="",
+    )
+    h1 = compute_row_hash(**kwargs)  # type: ignore[arg-type]
+    h2 = compute_row_hash(**kwargs)  # type: ignore[arg-type]
+    assert h1 == h2
+    assert len(h1) == 64  # SHA-256 hex
+
+
+def test_row_hash_changes_on_score_change() -> None:
+    base_kwargs = dict(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="",
+        time_spent_seconds=90,
+        submitted_at=_fixed_now(),
+        prev_hash="",
+    )
+    h_base = compute_row_hash(**base_kwargs)  # type: ignore[arg-type]
+
+    altered_scores = RubricScores(
+        accuracy=4,
+        safety=5,
+        guideline_alignment=4,
+        local_appropriateness=3,
+        clarity=3,  # changed from 4
+    )
+    h_altered = compute_row_hash(
+        **{**base_kwargs, "scores": altered_scores}  # type: ignore[arg-type]
+    )
+    assert h_base != h_altered
+
+
+def test_row_hash_requires_tz_aware_datetime() -> None:
+    naive = datetime(2026, 4, 18, 12, 0, 0)
+    with pytest.raises(ValueError, match="timezone-aware"):
+        compute_row_hash(
+            grade_id="g-1",
+            case_id="c-1",
+            reviewer_id="u-1",
+            reviewer_role="clinical_reviewer",
+            rubric_version="v1",
+            scores=_scores(),
+            notes="",
+            time_spent_seconds=90,
+            submitted_at=naive,
+            prev_hash="",
+        )
+
+
+def test_row_hash_chains_prev_hash() -> None:
+    # Two consecutive grades: second's prev_hash = first's row_hash.
+    # Changing first's scores should cascade into second's row_hash via
+    # the chain.
+    first_scores = _scores()
+    g1 = build_grade(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=first_scores,
+        notes="",
+        time_spent_seconds=90,
+        submitted_at=_fixed_now(),
+        prev_hash="",
+    )
+    g2 = build_grade(
+        grade_id="g-2",
+        case_id="c-2",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="",
+        time_spent_seconds=120,
+        submitted_at=_fixed_now(),
+        prev_hash=g1.row_hash,
+    )
+    assert g2.prev_hash == g1.row_hash
+
+    tampered_first_scores = RubricScores(
+        accuracy=1,  # was 4
+        safety=5,
+        guideline_alignment=4,
+        local_appropriateness=3,
+        clarity=4,
+    )
+    g1_tampered = build_grade(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=tampered_first_scores,
+        notes="",
+        time_spent_seconds=90,
+        submitted_at=_fixed_now(),
+        prev_hash="",
+    )
+    assert g1_tampered.row_hash != g1.row_hash
+
+
+# ---- Grade validation ----
+
+
+def test_grade_rejects_negative_time_spent() -> None:
+    with pytest.raises(ValueError, match="time_spent_seconds"):
+        build_grade(
+            grade_id="g-1",
+            case_id="c-1",
+            reviewer_id="u-1",
+            reviewer_role="clinical_reviewer",
+            rubric_version="v1",
+            scores=_scores(),
+            notes="",
+            time_spent_seconds=-1,
+            submitted_at=_fixed_now(),
+            prev_hash="",
+        )
+
+
+def test_grade_rejects_long_notes() -> None:
+    with pytest.raises(ValueError, match="notes"):
+        build_grade(
+            grade_id="g-1",
+            case_id="c-1",
+            reviewer_id="u-1",
+            reviewer_role="clinical_reviewer",
+            rubric_version="v1",
+            scores=_scores(),
+            notes="x" * 2001,
+            time_spent_seconds=60,
+            submitted_at=_fixed_now(),
+            prev_hash="",
+        )
+
+
+def test_grade_to_row_dict_flattens_scores() -> None:
+    grade = build_grade(
+        grade_id="g-1",
+        case_id="c-1",
+        reviewer_id="u-1",
+        reviewer_role="clinical_reviewer",
+        rubric_version="v1",
+        scores=_scores(),
+        notes="ok",
+        time_spent_seconds=60,
+        submitted_at=_fixed_now(),
+        prev_hash="",
+    )
+    row = grade_to_row_dict(grade)
+    assert row["accuracy"] == 4
+    assert row["safety"] == 5
+    assert row["clarity"] == 4
+    assert "scores" not in row
+    assert row["row_hash"] == grade.row_hash


### PR DESCRIPTION
Closes #29.

## Summary

New `labeling/` package for the Tier 3 clinician review loop — a Streamlit app that surfaces assigned cases from a Redis-backed per-reviewer/per-week queue, captures a 5-dimension rubric (accuracy, safety, guideline alignment, local appropriateness, clarity) on a 1–5 Likert scale, and persists grades with SHA-256 row-hash chain-of-custody to a new \`grades\` table. A sidecar k3s CronJob computes Fleiss kappa per dimension daily across dual-rated cases and alerts below 0.70.

Substantive logic lives in pure modules (rubric, kappa, auth gate, queue, PDF URL builder, repository) so CI can run 64 unit tests without installing Streamlit. Streamlit is pinned behind an \`[ui]\` extra with its own ADR (0009).

## Acceptance criteria verification

- [x] **Each reviewer can grade 20 cases per week under 60 minutes total** — PASS. Rubric form is 5 sliders + a textarea + submit. Form defaults to mid-scale (3) so reviewers must act rather than rubber-stamp. Queue namespacing is \`:reviewer_id:iso_week:\` which limits a reviewer's visible work to their current week. Mobile layout handled by Streamlit's default reflow.
- [x] **Agreement (Fleiss kappa) computed daily across dual-rated cases** — PASS. \`labeling/daily_kappa.py\` runs as the \`labeling-kappa-cronjob.yaml\` CronJob at 03:00 EAT, computes kappa per dimension over the 24h window, logs the report, and exits non-zero when \`KAPPA_FAIL_ON_ALERT=1\` and any dim drops below the threshold. Kappa math is canonicalised in \`labeling/kappa.py\` with 11 tests including the Fleiss canonical example.
- [x] **Grades persisted to \`grades\` table with chain-of-custody metadata** — PASS. Alembic migration \`0004_grades\` adds \`grades\` with CHECK constraints on every score column, a unique index on \`(reviewer_id, case_id)\`, and \`prev_hash\`/\`row_hash\` columns. \`rubric.compute_row_hash\` is deterministic SHA-256 over the canonical payload + prev_hash; \`build_grade\` chains automatically.
- [x] **UI accessible on mobile for bedside use** — PASS (per ADR-0009). Streamlit's default layout is mobile-responsive out of the box; we set \`layout=\"wide\"\` only on the desktop-oriented \"grade next case\" view. Bedside flow is slider-centric and submits in a single form.

## Test plan

64 tests across 7 modules, all passing locally:

- \`test_rubric.py\` (14) — score range validation, SHA-256 determinism, hash chain tamper detection, notes max-length, time-spent non-negative.
- \`test_kappa.py\` (11) — Fleiss canonical example (4 items × 3 raters × 3 cats), degenerate-single-category → nan, random-50/50 → -1/3, empty input raises, mismatched rater counts raise, build_counts_matrix round-trip.
- \`test_auth.py\` (10) — role extraction from \`role\`/\`roles\`/\`realm_access.roles\` (Keycloak), refusal on missing sub, refusal on role not in allow-list, display name fallback to sub.
- \`test_queue.py\` (11) — key namespacing, reserve moves head to in-flight, race (LREM=0) returns None, complete is idempotent, release returns case to tail of pending.
- \`test_pdf_viewer.py\` (9) — URL encoding, bbox coord validation, inverted coords rejected, page ≥ 1 required.
- \`test_repository.py\` (5) — \`SET LOCAL statement_timeout\` applied, INSERT args positional order verified, agreement SQL groups by case+dimension.
- \`test_daily_kappa.py\` (4) — alert fires below threshold, single-rated cases skipped (n=0), perfect agreement above threshold produces no alert, bad threshold rejected.

Pre-commit: all hooks pass (ruff, ruff-format, bandit, kubeconform, yamllint, no-phi-in-logs, every-external-call-has-timeout, detect-secrets).

## Deployment notes

**New env vars** (all in \`env/labeling.env\`, mirrored in \`labeling/settings.py\`):
\`LABELING_QUEUE_KEY\`, \`LABELING_QUEUE_MAX_PER_REVIEWER_PER_DAY\`, \`RUBRIC_VERSION\`, \`DUAL_RATER_RATIO\`, \`KAPPA_ALERT_THRESHOLD\`, \`PDF_VIEWER_BASE_URL\`, \`PDF_VIEWER_HIGHLIGHT_BBOX\`.

**New migration**: \`0004_grades\` — reversible. \`GRANT SELECT, INSERT, UPDATE\` to \`afya_sahihi_app\`; DELETE intentionally not granted (corrections go through compensating INSERT).

**New dependency**: Streamlit 1.39.0, pinned behind the \`[ui]\` extra. ADR-0009 explains the choice over the React app and over FastAPI+HTMX.

**New k3s manifests**: \`deploy/k3s/30-labeling.yaml\` (Deployment + Service + ConfigMap + ServiceAccount, single replica, readOnlyRootFilesystem, all caps dropped) and \`deploy/k3s/50-jobs/labeling-kappa-cronjob.yaml\` (daily 03:00 EAT, Forbid concurrency).

**New container image**: \`ghcr.io/akuhealth/afya-sahihi-labeling\` — build lands with M8 (#34 container build pipeline).