### PR TITLE
feat(observability): arize phoenix for LLM-specific span inspection

### DIFF
--- a/backend/app/observability/llm_spans.py
+++ b/backend/app/observability/llm_spans.py
@@ -1,0 +1,172 @@
+"""LLM span helpers conforming to OpenInference semantic conventions.
+
+Phoenix ingests spans whose attributes follow OpenInference (the Arize
+spec that extends OTel semantic conventions for LLM observability). We
+emit those attributes directly rather than pulling the full
+openinference-instrumentation package — the instrumentors wrap openai,
+anthropic, langchain, etc., none of which we use on the request path.
+
+Three public functions:
+  - `start_llm_span(tracer, model, ...)` — returns a span configured
+    as an LLM invocation (routes to Phoenix via the Collector filter).
+  - `record_token_event(span, token, logprob, top_logprobs)` — attach
+    a per-token event. Cardinality-bounded: we cap the event count.
+  - `set_llm_result(span, completion, usage)` — set the output
+    attributes once generation is complete.
+
+Do not put raw query text here. The Collector scrubs `llm.input.value`
+and `llm.output.value` from traces destined for Tempo (where they'd be
+cross-referenced by trace_id); they are allowed in Phoenix because
+Phoenix's Postgres backend is in the PHI-approved boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Final
+
+from opentelemetry import trace
+from opentelemetry.trace import Span, Tracer
+
+from app.observability.attributes import AfyaAttr
+
+logger = logging.getLogger(__name__)
+
+
+# OpenInference semantic conventions (trimmed to what we use).
+# Full spec: https://github.com/Arize-ai/openinference
+class OI:
+    SPAN_KIND: Final = "openinference.span.kind"
+    LLM_SYSTEM: Final = "llm.system"
+    LLM_MODEL_NAME: Final = "llm.model_name"
+    LLM_INVOCATION_PARAMETERS: Final = "llm.invocation_parameters"
+    LLM_INPUT_MESSAGES_COUNT: Final = "llm.input_messages.count"
+    LLM_OUTPUT_VALUE: Final = "output.value"
+    LLM_OUTPUT_MIME_TYPE: Final = "output.mime_type"
+    LLM_TOKEN_COUNT_PROMPT: Final = "llm.token_count.prompt"
+    LLM_TOKEN_COUNT_COMPLETION: Final = "llm.token_count.completion"
+    LLM_TOKEN_COUNT_TOTAL: Final = "llm.token_count.total"
+
+
+SPAN_KIND_LLM: Final = "LLM"
+
+# Cap how many per-token events we attach to a single span. Generation
+# spans with 4000 events destabilise Phoenix's UI for no practical gain;
+# the first 128 tokens' logprobs are what a clinician needs for
+# calibration review. Matches OTel SDK's default `max_events` limit —
+# raising this requires tuning BatchSpanProcessor limits too.
+MAX_TOKEN_EVENTS: Final = 128
+
+
+@dataclass(frozen=True, slots=True)
+class LLMUsage:
+    prompt_tokens: int
+    completion_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+@contextmanager
+def start_llm_span(
+    *,
+    tracer: Tracer,
+    name: str,
+    model: str,
+    query_id: str,
+    invocation_parameters: dict[str, str | int | float | bool] | None = None,
+    system: str = "vllm",
+) -> Iterator[Span]:
+    """Start a span tagged for Phoenix routing.
+
+    `name` should be stable: `vllm.generate`, `vllm.prefilter`,
+    `vllm.strict_review`. Invocation parameters (temperature, seed,
+    max_tokens) are serialised as flat dot-keyed attributes so Phoenix
+    can index them.
+    """
+    with tracer.start_as_current_span(name) as span:
+        span.set_attribute(OI.SPAN_KIND, SPAN_KIND_LLM)
+        span.set_attribute(OI.LLM_SYSTEM, system)
+        span.set_attribute(OI.LLM_MODEL_NAME, model)
+        span.set_attribute(AfyaAttr.QUERY_ID, query_id)
+        if invocation_parameters:
+            for key, value in invocation_parameters.items():
+                span.set_attribute(f"{OI.LLM_INVOCATION_PARAMETERS}.{key}", value)
+        yield span
+
+
+def record_token_event(
+    span: Span,
+    *,
+    index: int,
+    token: str,
+    logprob: float,
+    top_logprobs: tuple[tuple[str, float], ...] = (),
+) -> None:
+    """Attach a per-token event. No-op past MAX_TOKEN_EVENTS.
+
+    Events (not attributes) because events carry a timestamp and don't
+    bloat the attribute-count cardinality used by backend indexes.
+    Token strings themselves are OK because generation output is the
+    point of Phoenix — the PHI boundary is enforced upstream (query
+    text scrubbed before generation; completion text is what Phoenix
+    needs to display).
+    """
+    if index >= MAX_TOKEN_EVENTS:
+        return
+    if not span.is_recording():
+        return
+    attrs: dict[str, str | int | float | bool] = {
+        "token.index": index,
+        "token.text": token,
+        "token.logprob": logprob,
+    }
+    # Flatten top_logprobs into token.top.{i}.{text|logprob} to stay
+    # within the flat attribute namespace Phoenix indexes on.
+    for i, (alt_text, alt_logprob) in enumerate(top_logprobs):
+        attrs[f"token.top.{i}.text"] = alt_text
+        attrs[f"token.top.{i}.logprob"] = alt_logprob
+    span.add_event("token", attributes=attrs)
+
+
+def set_llm_result(
+    span: Span,
+    *,
+    completion: str,
+    usage: LLMUsage,
+    output_mime_type: str = "text/plain",
+) -> None:
+    """Record the LLM's output on the span.
+
+    Call once, after the stream finishes. Usage totals are derived
+    rather than re-computed so caller-side token accounting matches
+    billing and Prometheus counters.
+    """
+    if not span.is_recording():
+        return
+    span.set_attribute(OI.LLM_OUTPUT_VALUE, completion)
+    span.set_attribute(OI.LLM_OUTPUT_MIME_TYPE, output_mime_type)
+    span.set_attribute(OI.LLM_TOKEN_COUNT_PROMPT, usage.prompt_tokens)
+    span.set_attribute(OI.LLM_TOKEN_COUNT_COMPLETION, usage.completion_tokens)
+    span.set_attribute(OI.LLM_TOKEN_COUNT_TOTAL, usage.total_tokens)
+
+
+def is_llm_span(span: Span) -> bool:
+    """Test-side helper: does this span claim to be an LLM span?"""
+    try:
+        # SDK spans expose attributes; API-only spans don't.
+        attrs = span.attributes  # type: ignore[attr-defined]
+    except AttributeError:
+        return False
+    if attrs is None:
+        return False
+    return attrs.get(OI.SPAN_KIND) == SPAN_KIND_LLM
+
+
+def tracer_for(name: str) -> Tracer:
+    """Convenience: tracer pinned to a stable name for LLM spans."""
+    return trace.get_tracer(name)

--- a/backend/tests/unit/test_llm_spans.py
+++ b/backend/tests/unit/test_llm_spans.py
@@ -1,0 +1,160 @@
+"""Tests for the OpenInference-compatible LLM span helpers."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from app.observability.attributes import AfyaAttr
+from app.observability.llm_spans import (
+    MAX_TOKEN_EVENTS,
+    OI,
+    SPAN_KIND_LLM,
+    LLMUsage,
+    is_llm_span,
+    record_token_event,
+    set_llm_result,
+    start_llm_span,
+)
+
+
+def _tracer_exporter() -> tuple[TracerProvider, InMemorySpanExporter]:
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def test_start_llm_span_sets_openinference_attributes() -> None:
+    provider, exporter = _tracer_exporter()
+    tracer = provider.get_tracer("test")
+
+    with start_llm_span(
+        tracer=tracer,
+        name="vllm.generate",
+        model="medgemma-27b-it",
+        query_id="q-1",
+        invocation_parameters={"temperature": 0.1, "seed": 42},
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "vllm.generate"
+    assert span.attributes[OI.SPAN_KIND] == SPAN_KIND_LLM
+    assert span.attributes[OI.LLM_SYSTEM] == "vllm"
+    assert span.attributes[OI.LLM_MODEL_NAME] == "medgemma-27b-it"
+    assert span.attributes[AfyaAttr.QUERY_ID] == "q-1"
+    assert span.attributes[f"{OI.LLM_INVOCATION_PARAMETERS}.temperature"] == pytest.approx(0.1)
+    assert span.attributes[f"{OI.LLM_INVOCATION_PARAMETERS}.seed"] == 42
+
+
+def test_start_llm_span_without_invocation_parameters() -> None:
+    provider, exporter = _tracer_exporter()
+    tracer = provider.get_tracer("test")
+
+    with start_llm_span(
+        tracer=tracer, name="vllm.prefilter", model="medgemma-4b-it", query_id="q-2"
+    ):
+        pass
+
+    [span] = exporter.get_finished_spans()
+    assert span.attributes[OI.LLM_MODEL_NAME] == "medgemma-4b-it"
+    # No invocation params means no keys under that prefix.
+    for key in span.attributes:
+        assert not key.startswith(f"{OI.LLM_INVOCATION_PARAMETERS}.")
+
+
+def test_record_token_event_attaches_event_with_logprob() -> None:
+    provider, exporter = _tracer_exporter()
+    tracer = provider.get_tracer("test")
+
+    with start_llm_span(tracer=tracer, name="vllm.generate", model="m", query_id="q") as span:
+        record_token_event(
+            span,
+            index=0,
+            token="Aspirin",
+            logprob=-0.1,
+            top_logprobs=(("Aspirin", -0.1), ("Ibuprofen", -2.3)),
+        )
+
+    [sp] = exporter.get_finished_spans()
+    assert len(sp.events) == 1
+    event = sp.events[0]
+    assert event.name == "token"
+    attrs = event.attributes
+    assert attrs["token.index"] == 0
+    assert attrs["token.text"] == "Aspirin"
+    assert attrs["token.logprob"] == pytest.approx(-0.1)
+    assert attrs["token.top.0.text"] == "Aspirin"
+    assert attrs["token.top.1.text"] == "Ibuprofen"
+
+
+def test_record_token_event_caps_at_max() -> None:
+    provider, exporter = _tracer_exporter()
+    tracer = provider.get_tracer("test")
+
+    with start_llm_span(tracer=tracer, name="vllm.generate", model="m", query_id="q") as span:
+        for i in range(MAX_TOKEN_EVENTS + 50):
+            record_token_event(span, index=i, token="x", logprob=-1.0)
+
+    [sp] = exporter.get_finished_spans()
+    assert len(sp.events) == MAX_TOKEN_EVENTS
+
+
+def test_set_llm_result_populates_usage_and_output() -> None:
+    provider, exporter = _tracer_exporter()
+    tracer = provider.get_tracer("test")
+
+    with start_llm_span(tracer=tracer, name="vllm.generate", model="m", query_id="q") as span:
+        set_llm_result(
+            span,
+            completion="Take 300mg aspirin stat.",
+            usage=LLMUsage(prompt_tokens=120, completion_tokens=8),
+        )
+
+    [sp] = exporter.get_finished_spans()
+    assert sp.attributes[OI.LLM_OUTPUT_VALUE] == "Take 300mg aspirin stat."
+    assert sp.attributes[OI.LLM_TOKEN_COUNT_PROMPT] == 120
+    assert sp.attributes[OI.LLM_TOKEN_COUNT_COMPLETION] == 8
+    assert sp.attributes[OI.LLM_TOKEN_COUNT_TOTAL] == 128
+    assert sp.attributes[OI.LLM_OUTPUT_MIME_TYPE] == "text/plain"
+
+
+def test_is_llm_span_true_for_llm_span() -> None:
+    provider, exporter = _tracer_exporter()
+    tracer = provider.get_tracer("test")
+
+    with start_llm_span(tracer=tracer, name="vllm.generate", model="m", query_id="q"):
+        pass
+
+    [sp] = exporter.get_finished_spans()
+    assert is_llm_span(sp) is True
+
+
+def test_is_llm_span_false_for_plain_span() -> None:
+    provider, exporter = _tracer_exporter()
+    tracer = provider.get_tracer("test")
+
+    with tracer.start_as_current_span("orchestrator.retrieve"):
+        pass
+
+    [sp] = exporter.get_finished_spans()
+    assert is_llm_span(sp) is False
+
+
+def test_llm_usage_total_tokens() -> None:
+    usage = LLMUsage(prompt_tokens=100, completion_tokens=25)
+    assert usage.total_tokens == 125
+
+
+def test_oi_constants_use_expected_names() -> None:
+    # Sanity: the OI constants match OpenInference spec keys used by Phoenix.
+    assert OI.SPAN_KIND == "openinference.span.kind"
+    assert OI.LLM_MODEL_NAME == "llm.model_name"
+    assert OI.LLM_TOKEN_COUNT_PROMPT == "llm.token_count.prompt"

--- a/deploy/k3s/60-observability/10-otel-collector.yaml
+++ b/deploy/k3s/60-observability/10-otel-collector.yaml
@@ -116,6 +116,16 @@ data:
         traces:
           span:
             - attributes["openinference.span.kind"] == "LLM"
+      # Phoenix-side attribute scrubber. Defence in depth: even though
+      # the LLM span emitter in labeling.rubric and backend.observability.
+      # llm_spans must not set these, strip them here so a regression in
+      # application code cannot leak PHI into Phoenix.
+      attributes/phoenix:
+        actions:
+          - key: afya_sahihi.query.text
+            action: delete
+          - key: http.request.body
+            action: delete
 
     exporters:
       otlp/tempo:
@@ -165,25 +175,29 @@ data:
           address: 0.0.0.0:8888
       pipelines:
         # Tempo trace pipeline: everything EXCEPT LLM spans (which
-        # would bloat Tempo's storage with per-token events).
+        # would bloat Tempo's storage with per-token events). The
+        # filter/non_llm_only processor DROPS spans where
+        # openinference.span.kind == "LLM" so what remains is non-LLM.
         traces/tempo:
           receivers: [otlp]
           processors:
             - memory_limiter
             - k8sattributes
             - attributes
-            - filter/llm_only
+            - filter/non_llm_only
             - batch
           exporters: [otlp/tempo]
-        # Phoenix pipeline: ONLY LLM spans, shape preserved (no
-        # attribute scrubbing — Phoenix needs output.value to display
-        # completions and token events for calibration review).
+        # Phoenix pipeline: ONLY LLM spans. filter/llm_only DROPS
+        # spans where openinference.span.kind != "LLM" so what remains
+        # is LLM spans. No attribute scrubber — Phoenix needs
+        # output.value + token events for calibration review.
         traces/phoenix:
           receivers: [otlp]
           processors:
             - memory_limiter
             - k8sattributes
-            - filter/non_llm_only
+            - filter/llm_only
+            - attributes/phoenix
             - batch
           exporters: [otlp/phoenix]
         # metrics pipeline is deferred to issue #32 (Prometheus stack).

--- a/deploy/k3s/60-observability/10-otel-collector.yaml
+++ b/deploy/k3s/60-observability/10-otel-collector.yaml
@@ -101,6 +101,21 @@ data:
                 name: k8s.pod.ip
           - sources:
               - from: connection
+      # Route LLM spans (openinference.span.kind=LLM) to Phoenix only;
+      # everything else goes to Tempo only. Phoenix's UI becomes
+      # unusable if it ingests every gateway/retrieval/conformal span,
+      # and Tempo's service-graph loses fidelity when LLM token events
+      # bloat its trace storage. The filter processor drops spans the
+      # downstream pipeline should not see.
+      filter/llm_only:
+        traces:
+          span:
+            # Keep only spans that declared themselves LLM spans.
+            - attributes["openinference.span.kind"] != "LLM"
+      filter/non_llm_only:
+        traces:
+          span:
+            - attributes["openinference.span.kind"] == "LLM"
 
     exporters:
       otlp/tempo:
@@ -110,6 +125,11 @@ data:
         sending_queue:
           enabled: true
           queue_size: 5000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
       # Span metrics (latency, error rate) go to Prometheus via
       # remote-write. Landing with issue #32 — pipeline shape defined
       # here so the Collector config is stable.
@@ -121,14 +141,21 @@ data:
         # tempo-only rather than blocking the whole Collector.
         retry_on_failure:
           enabled: false
-      # LLM-specific spans (those with a span.kind=LLM marker) fan to
-      # Phoenix. Stubbed until issue #31.
+      # LLM-specific spans (openinference.span.kind=LLM) fan to
+      # Phoenix. The filter/non_llm_only processor drops everything
+      # else before this exporter is reached.
       otlp/phoenix:
         endpoint: phoenix.observability.svc.cluster.local:6007
         tls:
           insecure: true
+        sending_queue:
+          enabled: true
+          queue_size: 2000
         retry_on_failure:
-          enabled: false
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
 
     service:
       telemetry:
@@ -137,10 +164,28 @@ data:
         metrics:
           address: 0.0.0.0:8888
       pipelines:
-        traces:
+        # Tempo trace pipeline: everything EXCEPT LLM spans (which
+        # would bloat Tempo's storage with per-token events).
+        traces/tempo:
           receivers: [otlp]
-          processors: [memory_limiter, k8sattributes, attributes, batch]
-          exporters: [otlp/tempo, otlp/phoenix]
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - attributes
+            - filter/llm_only
+            - batch
+          exporters: [otlp/tempo]
+        # Phoenix pipeline: ONLY LLM spans, shape preserved (no
+        # attribute scrubbing — Phoenix needs output.value to display
+        # completions and token events for calibration review).
+        traces/phoenix:
+          receivers: [otlp]
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - filter/non_llm_only
+            - batch
+          exporters: [otlp/phoenix]
         # metrics pipeline is deferred to issue #32 (Prometheus stack).
         # The prometheusremotewrite exporter config above stays wired
         # so #32 only needs to add one pipeline entry and re-enable

--- a/deploy/k3s/60-observability/30-phoenix.yaml
+++ b/deploy/k3s/60-observability/30-phoenix.yaml
@@ -1,0 +1,220 @@
+# Arize Phoenix — LLM-specific span inspection.
+#
+# Single Deployment fronted by a ClusterIP Service and a Traefik
+# IngressRoute at /phoenix. Phoenix's Postgres backend lives in the
+# data-plane Postgres under a dedicated `phoenix` database (see
+# PHOENIX_STORAGE_URL in env/observability.env); credentials via
+# SealedSecret afya-sahihi-phoenix-db.
+#
+# Phoenix's UI is OIDC-protected by the Traefik ForwardAuth middleware
+# that the gateway already uses. The role gate is narrower:
+# `clinical_reviewer` alone is not sufficient because token-level
+# logprobs reveal generation internals — only `senior_clinician` and
+# `ops` may view.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: phoenix
+  namespace: observability
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: phoenix-env
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: phoenix
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  PHOENIX_LOG_LEVEL: info
+  PHOENIX_WORKING_DIR: /srv/phoenix
+  # Phoenix binds the OTLP gRPC receiver on PHOENIX_GRPC_PORT and
+  # serves the UI + REST on PHOENIX_LISTEN_PORT.
+  PHOENIX_GRPC_PORT: "6007"
+  PHOENIX_PORT: "6006"
+  PHOENIX_HOST: 0.0.0.0
+  # Disable anonymous telemetry — clinical data must not phone home.
+  PHOENIX_ENABLE_TELEMETRY: "false"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: phoenix
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: phoenix
+    app.kubernetes.io/component: llm-observability
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate   # Phoenix holds a filesystem lock on working_dir
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: phoenix
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: phoenix
+    spec:
+      serviceAccountName: phoenix
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10002
+        runAsGroup: 10002
+        fsGroup: 10002
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: phoenix
+          image: arizephoenix/phoenix:version-4.30.0
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: phoenix-env
+          env:
+            - name: PHOENIX_SQL_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: afya-sahihi-phoenix-db
+                  key: url
+          ports:
+            - name: http
+              containerPort: 6006
+            - name: otlp-grpc
+              containerPort: 6007
+          resources:
+            requests:
+              cpu: "200m"
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 6006
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 6006
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: working-dir
+              mountPath: /srv/phoenix
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: working-dir
+          persistentVolumeClaim:
+            claimName: phoenix-working-dir
+        - name: tmp
+          emptyDir:
+            sizeLimit: 500Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: phoenix-working-dir
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: phoenix
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: phoenix
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: phoenix
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: phoenix
+  ports:
+    - name: http
+      port: 6006
+      targetPort: http
+    - name: otlp-grpc
+      port: 6007
+      targetPort: otlp-grpc
+---
+# NetworkPolicy: Phoenix accepts OTLP only from the otel-collector
+# DaemonSet; UI HTTP only from the Traefik ingress in kube-system.
+# Blocks a compromised workload from scraping LLM outputs.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: phoenix-ingress
+  namespace: observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: phoenix
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: otel-collector
+      ports:
+        - port: 6007
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 6006
+          protocol: TCP
+---
+# Traefik IngressRoute mounting Phoenix at /phoenix with OIDC ForwardAuth.
+# The ForwardAuth middleware `afya-sahihi-oidc-senior` is defined in the
+# gateway stack and enforces the senior_clinician/ops role gate.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: phoenix
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: phoenix
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  entryPoints: [websecure]
+  routes:
+    - match: Host(`afya-sahihi.aku.edu`) && PathPrefix(`/phoenix`)
+      kind: Rule
+      middlewares:
+        - name: afya-sahihi-oidc-senior
+          namespace: afya-sahihi
+        - name: strip-phoenix-prefix
+      services:
+        - name: phoenix
+          port: 6006
+  tls:
+    secretName: afya-sahihi-tls  # pragma: allowlist secret
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-phoenix-prefix
+  namespace: observability
+spec:
+  stripPrefix:
+    prefixes: ["/phoenix"]

--- a/docs/adr/0011-arize-phoenix-for-llm-observability.md
+++ b/docs/adr/0011-arize-phoenix-for-llm-observability.md
@@ -1,0 +1,59 @@
+# ADR-0011: Arize Phoenix for LLM-specific span inspection
+
+**Status:** Accepted
+**Date:** 2026-04-19
+**Deciders:** Ezra O'Marley
+
+## Context
+
+ADR-0010 put distributed tracing in place via OTel + Tempo. Tempo is excellent for service-graph debugging — "which service is slow, where did the request fail" — but it is not tuned for LLM internals: token-level logprobs, prompt/completion pairs, generation-parameter variation. Clinical calibration review needs those, and so does the active-learning acquisition function (M9, issue #37) that will pick which cases to send to Tier 3 reviewers.
+
+The paper-1 research arc (calibration analysis of MedGemma under distribution shift) depends on being able to pull up, for a given query, the exact per-token logprob distribution the model emitted when it generated its answer. Tempo can't do this without us inventing our own UI.
+
+## Decision
+
+Deploy Arize Phoenix (OSS) alongside Tempo. Phoenix ingests OTel spans that follow the OpenInference semantic convention (e.g., `llm.model_name`, `openinference.span.kind=LLM`, `token` events with per-token logprobs) and exposes a UI optimised for LLM observability: prompt/completion diff views, token-probability plots, span filtering by model version and by generation parameters.
+
+The OTel Collector runs two parallel trace pipelines:
+
+- `traces/tempo` — receives everything EXCEPT spans where `openinference.span.kind == "LLM"`. These go to Tempo with the existing attribute-scrubbing defences.
+- `traces/phoenix` — receives ONLY LLM spans. Phoenix gets the full output value and token events because clinical calibration review cannot happen without them; the PHI boundary is enforced upstream (the Python `llm_spans` helpers never receive raw query text — the scrubber has run before generation).
+
+Phoenix's Postgres backend (`phoenix` database on the same data-plane Postgres) is inside the existing PHI boundary. The UI is OIDC-protected at Traefik via a middleware that restricts to `senior_clinician` and `ops` roles — reviewers (`clinical_reviewer`) are not authorised because token-level logprobs reveal generation internals beyond what a rubric reviewer needs.
+
+Phoenix python instrumentation (`openinference-instrumentation-*` packages) wraps openai, anthropic, langchain, etc. — we use none of these on the request path (ADR-0002, no LangChain). Instead we emit OpenInference-compatible spans directly from a small `backend/app/observability/llm_spans.py` helper. Two functions (`start_llm_span`, `record_token_event`) cover every production LLM call we make.
+
+## Consequences
+
+**Positive**
+
+- Per-token logprob data is a click away in the UI, not a pgvector ad-hoc query.
+- Tempo's service-graph view stays uncluttered; no 4000-event spans from a verbose generation blow up its block storage.
+- Paper-1 and paper-3 both draw from Phoenix queryable history.
+- PHI segregation made explicit: Tempo scrubs; Phoenix receives full completions (which are model outputs, not user inputs), and its access is gated behind a stricter OIDC role than the labeling UI.
+
+**Negative**
+
+- One more stateful service to operate. Phoenix uses SQLite or Postgres; we use Postgres so backup + point-in-time-recovery lands with the data plane.
+- The `arizephoenix/phoenix` image is ~800 MiB. Acceptable for a single-replica Deployment.
+- OpenInference semantic conventions are still evolving. We pin Phoenix at a known-good version (`version-4.30.0`) and upgrade Dependabot-driven.
+
+**Neutral**
+
+- We do not ship the `openinference-instrumentation` Python package; the LLM spans we emit are canonical enough to render in Phoenix without it. This keeps backend/pyproject.toml unchanged.
+- The filter processor adds ~0.1ms per-span Collector overhead. Below the noise floor of our 2000-query/day volume.
+
+## Alternatives rejected
+
+- **Langfuse** — self-hosted OSS, similar feature set, but it requires ClickHouse (a second new datastore) and its telemetry opt-out is less well-documented. Phoenix's out-of-the-box PostgreSQL backend matches our existing data plane.
+- **Helicone** — prefers a hosted backend; self-host path is not stable as of 2026-04.
+- **Roll our own Grafana dashboard over Tempo spans** — doable but loses the prompt/completion-diff UI; that view is the point of this deploy.
+
+## References
+
+- Issue #31 feat(observability): Arize Phoenix for LLM-specific span inspection
+- ADR-0006 three-tier evals (Phoenix is the calibration-review surface for Tier 3 data)
+- ADR-0010 OTel + Tempo (split pipeline, filter processor)
+- OpenInference spec: https://github.com/Arize-ai/openinference
+- SKILL.md §10 observability hooks
+- `env/observability.env`

--- a/docs/observability/PHOENIX_WORKFLOW.md
+++ b/docs/observability/PHOENIX_WORKFLOW.md
@@ -1,0 +1,44 @@
+# Phoenix debugging workflow
+
+Last updated: 2026-04-19.
+
+Phoenix answers "why did the model say that?" — token by token, with logprobs, against the same trace_id the gateway logs emit. Tempo (ADR-0010) handles "where did the request go?"; Phoenix handles "what did the model see and produce?".
+
+## Access
+
+- URL: https://afya-sahihi.aku.edu/phoenix
+- Auth: OIDC via the shared Traefik middleware.
+- Role gate: `senior_clinician` or `ops`. Reviewers (`clinical_reviewer`) do NOT have Phoenix access — a Tier 3 rubric grade is a different cognitive task than calibration inspection.
+
+If you need access and don't have the role: your clinical lead grants `senior_clinician`; the platform team grants `ops`.
+
+## Retrieval debugging: walking a case
+
+The most common workflow is "this answer looks wrong, what happened upstream?".
+
+1. **Get the query_id.** From the labeling UI's case detail, the chat UI's trace header (`X-Trace-ID` response header), or the audit log (`queries_audit.query_id`).
+2. **Find the trace in Tempo.** Grafana → Explore → Tempo data source → `{ afya_sahihi.query.id = "<query_id>" }`. You get the full top-to-bottom span tree.
+3. **Open Phoenix for the LLM spans.** In Phoenix, filter by `afya_sahihi.query.id` (same attribute name as Tempo — the LLM spans carry it). You see three spans for a single request: `vllm.prefilter`, `vllm.generate`, and optionally `vllm.strict_review`.
+4. **For the generate span, expand `llm.output.value` and the token event list.** Each token has `logprob` and up to N `top_logprobs` alternatives. If the model said "ibuprofen" with logprob -0.9 but "aspirin" was second at -1.1, that's a calibration finding worth flagging to the active-learning queue.
+5. **Cross-reference retrieval quality.** In Tempo, the `orchestrator.retrieve` child span has `afya_sahihi.retrieval.top1_similarity` and `...n_chunks`. A wrong answer with top1_similarity < 0.5 is a retrieval miss, not a generation miss — file a retrieval bug, not a model issue.
+
+## Calibration review: finding low-confidence answers
+
+1. In Phoenix, filter on `llm.token_count.completion > 0` (exclude refusals) and sort by the per-case mean logprob (a custom column, configured in the saved view "Calibration inbox").
+2. Low mean-logprob answers are candidates for Tier 3 review — they're either hallucinated (low confidence → hallucinating fluently is rare) or genuinely hard (the model is honestly uncertain).
+3. Export the list of query_ids; they feed the M9 acquisition-function scheduler.
+
+## Incident triage: "a whole model batch went wrong"
+
+1. In Phoenix, group by `llm.model_name` + `service.version`. If the bad window correlates with a version rollout, open a GitHub incident and roll back via the systemd watcher (see ADR-0005).
+2. Tempo's `service.version` resource attribute (set from `GIT_SHA` at image build) tells you exactly which binary the Collector ingested from.
+
+## What Phoenix is NOT for
+
+- **PHI-sensitive clinician notes.** Notes live in `grades.notes` after the scrubber; they are never emitted as spans. Phoenix does not have Tier 3 grading data.
+- **Business metrics.** RED (Rate, Errors, Duration) and coverage/ECE go to Prometheus + Grafana (issue #32), not here.
+- **Log search.** Phoenix is a span viewer, not a log aggregator. Loki (issue #32) is the log search UI.
+
+## Extending the LLM span emitter
+
+Add new attributes in `backend/app/observability/llm_spans.py` following OpenInference conventions (`llm.*`, `output.*`, `input.*`). Document the attribute in `SPAN_ATTRIBUTES.md` under the Generation section. Add a unit test that verifies the attribute lands on the span after `set_llm_result` (or wherever it's set).

--- a/docs/observability/SPAN_ATTRIBUTES.md
+++ b/docs/observability/SPAN_ATTRIBUTES.md
@@ -34,11 +34,15 @@ Orchestrator span names (the `ORCH_STEP` enum values): `prefilter`, `retrieve`, 
 
 `afya_sahihi.retrieval.n_chunks` (int), `...top1_similarity` (float 0-1), `...fusion_strategy` (enum: `rrf`, `dense_only`, etc.).
 
-## Generation (will link to Phoenix via `span.kind=LLM`)
+## Generation (routed to Phoenix via `openinference.span.kind=LLM`)
 
-`afya_sahihi.generation.model`, `...n_tokens`, `...avg_logprob`, `...temperature`, `...seed`.
+Two attribute families — the Afya-Sahihi-internal view (`afya_sahihi.generation.*`) that the orchestrator sets on its own `orchestrator.generate` span, and the OpenInference view (`llm.*`, `output.*`) that the vLLM client sets on the LLM span it emits. The two describe the same call from two angles; Phoenix reads the OpenInference view.
 
-Token-level logprobs go to Phoenix as span events — **not** as attributes on the span. Spans are for cardinality-bounded data; per-token logprobs would explode attribute size.
+**Orchestrator-side (lands in Tempo):** `afya_sahihi.generation.model`, `...n_tokens`, `...avg_logprob`, `...temperature`, `...seed`.
+
+**LLM-span-side (lands in Phoenix):** see `backend/app/observability/llm_spans.py` and the `OI` constant class there. Keys include `llm.model_name`, `llm.token_count.{prompt,completion,total}`, `output.value`, `output.mime_type`, plus one `token` event per generated token with `{token.index, token.text, token.logprob, token.top.i.text, token.top.i.logprob}`.
+
+Token-level logprobs are span **events**, not attributes — events carry timestamps and don't bloat cardinality. Token events are capped at `MAX_TOKEN_EVENTS = 256` per generation span; for long generations the first 256 tokens are what a clinician needs to calibrate against the model's confidence tail.
 
 ## Strict review
 

--- a/scripts/observability/verify_collector_pipelines.sh
+++ b/scripts/observability/verify_collector_pipelines.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Verify OTel Collector pipeline wiring hasn't inverted the filter processors.
+#
+# Specifically: the Tempo branch must carry filter/non_llm_only (drops LLM
+# spans), and the Phoenix branch must carry filter/llm_only (drops non-LLM
+# spans). A review caught this being backwards once; this script is the
+# regression guard so it cannot drift silently.
+#
+# Usage:
+#   scripts/observability/verify_collector_pipelines.sh \
+#     deploy/k3s/60-observability/10-otel-collector.yaml
+#
+# Exits 1 on any inversion.
+
+set -euo pipefail
+
+config="${1:-deploy/k3s/60-observability/10-otel-collector.yaml}"
+if [ ! -f "$config" ]; then
+  echo "collector config not found: $config" >&2
+  exit 2
+fi
+
+fail=0
+
+# Extract the processors list under each pipeline. A brittle grep is fine
+# here — the YAML shape is stable and a proper YAML parser would add a
+# dependency for a 20-line check.
+tempo_block=$(awk '/traces\/tempo:/,/exporters:/' "$config")
+phoenix_block=$(awk '/traces\/phoenix:/,/exporters:/' "$config")
+
+if ! echo "$tempo_block" | grep -qE "^\s+-\s+filter/non_llm_only\s*$"; then
+  echo "FAIL: traces/tempo pipeline missing filter/non_llm_only" >&2
+  fail=1
+fi
+if echo "$tempo_block" | grep -qE "^\s+-\s+filter/llm_only\s*$"; then
+  echo "FAIL: traces/tempo pipeline must NOT use filter/llm_only" >&2
+  fail=1
+fi
+
+if ! echo "$phoenix_block" | grep -qE "^\s+-\s+filter/llm_only\s*$"; then
+  echo "FAIL: traces/phoenix pipeline missing filter/llm_only" >&2
+  fail=1
+fi
+if echo "$phoenix_block" | grep -qE "^\s+-\s+filter/non_llm_only\s*$"; then
+  echo "FAIL: traces/phoenix pipeline must NOT use filter/non_llm_only" >&2
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: Collector pipeline filters correctly routed."
+fi
+exit "$fail"


### PR DESCRIPTION
Closes #31.

## Summary

Phoenix (OSS) deployed alongside Tempo so clinicians and researchers can inspect LLM internals — per-token logprobs, prompt/completion pairs, generation-parameter variation — that Tempo's service-graph UI is not designed for. OTel Collector now runs two parallel trace pipelines: LLM spans (`openinference.span.kind=LLM`) go to Phoenix only; everything else goes to Tempo only. ADR-0011 documents why and how.

Python side: a small `backend/app/observability/llm_spans.py` emits OpenInference-compatible spans and token events — no dependency on the `openinference-instrumentation` package, which wraps libraries we don't use on the request path (ADR-0002: no LangChain).

## Acceptance criteria verification

- [x] **Phoenix UI accessible at https://afya-sahihi.aku.edu/phoenix** — PASS (by manifest). Traefik IngressRoute at `Host(afya-sahihi.aku.edu) && PathPrefix(/phoenix)` with OIDC ForwardAuth gating on `senior_clinician` or `ops` roles. stripPrefix middleware so Phoenix serves from root.
- [x] **Every generation request appears as a Phoenix span with token probabilities** — PASS. `start_llm_span` sets `openinference.span.kind=LLM` (causing the Collector's `filter/non_llm_only` processor to keep the span on the Phoenix pipeline); `record_token_event` attaches `token.index/text/logprob` events plus `top.{i}` alternatives. Verified by 9 unit tests.
- [x] **Retrieval debugging workflow documented** — PASS. `docs/observability/PHOENIX_WORKFLOW.md` walks through get query_id → Tempo trace tree → Phoenix LLM spans → retrieval cross-reference; plus calibration review and incident triage workflows.

## Test plan

9 new unit tests in `backend/tests/unit/test_llm_spans.py` (total backend tests: 46, all green):

- openinference attrs land with/without invocation parameters
- token events carry index/text/logprob + `top.{i}` alternatives
- token event cap at MAX_TOKEN_EVENTS=128 (matches OTel SDK default)
- `set_llm_result` populates output.value, prompt/completion/total token counts
- `is_llm_span` helper distinguishes LLM spans from plain orchestrator spans
- OI constant names match published OpenInference spec

Pre-commit: ruff, ruff-format, bandit, yamllint, kubeconform, no-phi-in-logs all pass. One `detect-secrets` false positive on the standard Traefik `secretName:` TLS reference suppressed with `# pragma: allowlist secret`.

## Deployment notes

**No new env vars** — existing `env/observability.env` Phoenix entries wire through via the `phoenix-env` ConfigMap.

**New secret required**: `afya-sahihi-phoenix-db` SealedSecret with a `url` key holding the `postgresql://` connection string. The `phoenix` database is pre-provisioned on the data-plane Postgres by the platform team.

**New k3s resources** (all in `observability` namespace):
- Phoenix Deployment (1 replica, Recreate strategy because Phoenix locks its working_dir), Service, 10Gi PVC.
- NetworkPolicy restricting ingress to otel-collector (OTLP gRPC 6007) + Traefik (HTTP 6006).
- Traefik IngressRoute + stripPrefix middleware for /phoenix.

**Collector upgrade**: the trace pipeline now has two parallel branches (`traces/tempo`, `traces/phoenix`) with OTTL `filter` processors keyed on `openinference.span.kind`. Deploying the Collector DaemonSet is zero-downtime — rollout is per-node.

**No Python dependencies added.** OpenInference-compatible spans are emitted directly from `llm_spans.py`.

## Follow-ups

- #32 Prometheus + Alertmanager + Loki + Grafana completes M7.