### PR TITLE
feat(deploy): k3s manifests for every backend service

### DIFF
--- a/deploy/k3s/11-retrieval.yaml
+++ b/deploy/k3s/11-retrieval.yaml
@@ -1,0 +1,304 @@
+# Retrieval service — hybrid dense + BM25 + RRF fusion + cross-encoder
+# rerank. Internal-only: only the gateway calls it. No IngressRoute.
+#
+# Stamped from 10-gateway.yaml with service-specific env and a
+# narrower NetworkPolicy (ingress from gateway only).
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: retrieval-config
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: retrieval
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  SERVICE_NAME: afya-sahihi-retrieval
+  SERVICE_PORT: "8081"
+  SERVICE_WORKERS: "2"
+  SERVICE_LOG_LEVEL: info
+  SERVICE_LOG_FORMAT: json
+  CORPUS_VERSION: v1.0
+  OTEL_SERVICE_NAME: afya-sahihi-retrieval
+  OTEL_SERVICE_NAMESPACE: afya-sahihi
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.observability.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_SAMPLER_RATIO: "1.0"
+  DEPLOYMENT_ENV: dev
+  # Retrieval tuning (ADR-0002)
+  RETRIEVAL_TOP_K: "6"
+  RETRIEVAL_CANDIDATES: "40"
+  RETRIEVAL_RRF_K: "60"
+  RETRIEVAL_DENSE_WEIGHT: "0.6"
+  RETRIEVAL_SPARSE_WEIGHT: "0.4"
+  RETRIEVAL_RERANK_MODEL: BAAI/bge-reranker-v2-m3
+  RETRIEVAL_RERANK_TOP_K: "6"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: retrieval
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: retrieval
+    app.kubernetes.io/part-of: afya-sahihi
+    app.kubernetes.io/component: rag
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: retrieval
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: retrieval
+        app.kubernetes.io/part-of: afya-sahihi
+        app.kubernetes.io/component: rag
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: retrieval
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: retrieval
+      containers:
+        - name: retrieval
+          image: harbor.aku.edu/afya-sahihi/retrieval:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: retrieval-config
+            - secretRef:
+                name: retrieval-secrets
+          resources:
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"  # cross-encoder reranker holds model weights
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            failureThreshold: 60  # 5 min for model load
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: model-cache
+              mountPath: /app/.cache
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: model-cache
+          emptyDir:
+            sizeLimit: 4Gi
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: retrieval
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: retrieval
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: retrieval
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: retrieval
+  namespace: afya-sahihi
+automountServiceAccountToken: false
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: retrieval
+  namespace: afya-sahihi
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: retrieval
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: retrieval
+  namespace: afya-sahihi
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: retrieval
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: retrieval
+  namespace: afya-sahihi
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: retrieval
+  policyTypes: [Ingress, Egress]
+  ingress:
+    # Only the gateway may call retrieval on :8081.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: gateway
+      ports:
+        - port: 8081
+          protocol: TCP
+    # Prometheus scrapes :9090.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 9090
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Postgres for hybrid search + MinIO for chunk blobs (if any).
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.10/32
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 9000
+          protocol: TCP
+    # OTel collector for spans.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: otel-collector
+      ports:
+        - port: 4317
+          protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: retrieval
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: retrieval
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: retrieval
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics

--- a/deploy/k3s/12-conformal.yaml
+++ b/deploy/k3s/12-conformal.yaml
@@ -1,0 +1,260 @@
+# Conformal prediction service — split conformal q_hat lookup +
+# prediction-set construction + drift monitor. Internal-only.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: conformal-config
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: conformal
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  SERVICE_NAME: afya-sahihi-conformal
+  SERVICE_PORT: "8082"
+  SERVICE_WORKERS: "2"
+  SERVICE_LOG_LEVEL: info
+  SERVICE_LOG_FORMAT: json
+  CORPUS_VERSION: v1.0
+  OTEL_SERVICE_NAME: afya-sahihi-conformal
+  OTEL_SERVICE_NAMESPACE: afya-sahihi
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.observability.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_SAMPLER_RATIO: "1.0"
+  DEPLOYMENT_ENV: dev
+  # Conformal tuning (ADR-0006, issue #25)
+  CONFORMAL_ALPHA: "0.10"
+  CONFORMAL_MIN_CAL_SAMPLES: "200"
+  CONFORMAL_COVERAGE_TARGET: "0.90"
+  CONFORMAL_COVERAGE_DEVIATION_MAX: "0.03"
+  DRIFT_WINDOW_SECONDS: "3600"
+  DRIFT_MMD_ALERT_THRESHOLD: "0.15"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: conformal
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: conformal
+    app.kubernetes.io/part-of: afya-sahihi
+    app.kubernetes.io/component: conformal
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: conformal
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: conformal
+        app.kubernetes.io/part-of: afya-sahihi
+        app.kubernetes.io/component: conformal
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: conformal
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: conformal
+      containers:
+        - name: conformal
+          image: harbor.aku.edu/afya-sahihi/conformal:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8082
+            - name: metrics
+              containerPort: 9090
+          envFrom:
+            - configMapRef:
+                name: conformal-config
+            - secretRef:
+                name: conformal-secrets
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /readyz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
+          startupProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 256Mi }
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: conformal
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: conformal
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: conformal
+  ports:
+    - name: http
+      port: 8082
+      targetPort: http
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: conformal
+  namespace: afya-sahihi
+automountServiceAccountToken: false
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: conformal
+  namespace: afya-sahihi
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: conformal
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: conformal
+  namespace: afya-sahihi
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: conformal
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target: { type: Utilization, averageUtilization: 70 }
+    - type: Resource
+      resource:
+        name: memory
+        target: { type: Utilization, averageUtilization: 80 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: conformal
+  namespace: afya-sahihi
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: conformal
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: gateway
+      ports:
+        - port: 8082
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 9090
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock: { cidr: 10.0.0.10/32 }
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: otel-collector
+      ports:
+        - port: 4317
+          protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: conformal
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: conformal
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: conformal
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics

--- a/deploy/k3s/13-audit.yaml
+++ b/deploy/k3s/13-audit.yaml
@@ -1,0 +1,259 @@
+# Audit log writer — receives structured events from the gateway +
+# conformal + retrieval and appends to `queries_audit` with hash-chain
+# (ADR-0008 / migration 0003). Write-heavy, single-tenant Postgres.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit-config
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: audit
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  SERVICE_NAME: afya-sahihi-audit
+  SERVICE_PORT: "8083"
+  SERVICE_WORKERS: "2"
+  SERVICE_LOG_LEVEL: info
+  SERVICE_LOG_FORMAT: json
+  OTEL_SERVICE_NAME: afya-sahihi-audit
+  OTEL_SERVICE_NAMESPACE: afya-sahihi
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.observability.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_SAMPLER_RATIO: "1.0"
+  DEPLOYMENT_ENV: dev
+  AUDIT_RETENTION_DAYS: "2555"         # 7y compliance retention
+  AUDIT_BATCH_SIZE: "50"
+  AUDIT_BATCH_TIMEOUT_MS: "500"
+  AUDIT_HASH_ALGORITHM: sha256
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: audit
+    app.kubernetes.io/part-of: afya-sahihi
+    app.kubernetes.io/component: audit
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: audit
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: audit
+        app.kubernetes.io/part-of: afya-sahihi
+        app.kubernetes.io/component: audit
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: audit
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: audit
+      containers:
+        - name: audit
+          image: harbor.aku.edu/afya-sahihi/audit:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8083
+            - name: metrics
+              containerPort: 9090
+          envFrom:
+            - configMapRef:
+                name: audit-config
+            - secretRef:
+                name: audit-secrets
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /readyz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
+          startupProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
+          lifecycle:
+            preStop:
+              exec:
+                # Longer drain — audit is fire-and-forget from callers
+                # but we want in-flight inserts to flush.
+                command: ["/bin/sh", "-c", "sleep 20"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 256Mi }
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: audit
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: audit
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: audit
+  ports:
+    - name: http
+      port: 8083
+      targetPort: http
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: audit
+  namespace: afya-sahihi
+automountServiceAccountToken: false
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: audit
+  namespace: afya-sahihi
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: audit
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: audit
+  namespace: afya-sahihi
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: audit
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target: { type: Utilization, averageUtilization: 70 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: audit
+  namespace: afya-sahihi
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: audit
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                # gateway + conformal + retrieval all write audit
+                # events. Labeling writes grades via its own repo.
+                values: [gateway, conformal, retrieval]
+      ports:
+        - port: 8083
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 9090
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock: { cidr: 10.0.0.10/32 }
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: otel-collector
+      ports:
+        - port: 4317
+          protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: audit
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: audit
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: audit
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics

--- a/deploy/k3s/14-prefilter.yaml
+++ b/deploy/k3s/14-prefilter.yaml
@@ -1,0 +1,257 @@
+# Prefilter service — topic/safety classifier head fronting the
+# MedGemma-4B instance on the GPU node (ADR-0007, issue #16). Every
+# query goes through here before the 27B generation path; this is the
+# gate that refuses out-of-domain or unsafe queries.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prefilter-config
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: prefilter
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  SERVICE_NAME: afya-sahihi-prefilter
+  SERVICE_PORT: "8084"
+  SERVICE_WORKERS: "2"
+  SERVICE_LOG_LEVEL: info
+  SERVICE_LOG_FORMAT: json
+  OTEL_SERVICE_NAME: afya-sahihi-prefilter
+  OTEL_SERVICE_NAMESPACE: afya-sahihi
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.observability.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_SAMPLER_RATIO: "1.0"
+  DEPLOYMENT_ENV: dev
+  # Prefilter tuning
+  PREFILTER_TOPIC_THRESHOLD: "0.65"
+  PREFILTER_SAFETY_STRICT: "true"
+  VLLM_4B_BASE_URL: http://afya-sahihi-gpu-01.internal:8001/v1
+  VLLM_4B_MODEL_NAME: medgemma-4b-it
+  VLLM_4B_TIMEOUT_SECONDS: "10"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefilter
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: prefilter
+    app.kubernetes.io/part-of: afya-sahihi
+    app.kubernetes.io/component: prefilter
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prefilter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prefilter
+        app.kubernetes.io/part-of: afya-sahihi
+        app.kubernetes.io/component: prefilter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: prefilter
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: prefilter
+      containers:
+        - name: prefilter
+          image: harbor.aku.edu/afya-sahihi/prefilter:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8084
+            - name: metrics
+              containerPort: 9090
+          envFrom:
+            - configMapRef:
+                name: prefilter-config
+            - secretRef:
+                name: prefilter-secrets
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /readyz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
+          startupProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 256Mi }
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prefilter
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: prefilter
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: prefilter
+  ports:
+    - name: http
+      port: 8084
+      targetPort: http
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prefilter
+  namespace: afya-sahihi
+automountServiceAccountToken: false
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: prefilter
+  namespace: afya-sahihi
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prefilter
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: prefilter
+  namespace: afya-sahihi
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: prefilter
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target: { type: Utilization, averageUtilization: 70 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prefilter
+  namespace: afya-sahihi
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prefilter
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: gateway
+      ports:
+        - port: 8084
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 9090
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # vLLM-4B on the GPU node.
+    - to:
+        - ipBlock: { cidr: 10.0.0.20/32 }
+      ports:
+        - port: 8001
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: otel-collector
+      ports:
+        - port: 4317
+          protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prefilter
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: prefilter
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prefilter
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics

--- a/deploy/k3s/16-eval-runner.yaml
+++ b/deploy/k3s/16-eval-runner.yaml
@@ -1,0 +1,228 @@
+# Eval runner — long-running status + API surface for the three-tier
+# Inspect AI eval harness (ADR-0006). The Tier 1 runs per commit in
+# CI; the Tier 2 nightly runs as a CronJob (50-jobs/tier2-eval-cronjob.yaml).
+# This Deployment is the HTTP API that serves eval-run status and
+# history for Grafana's eval dashboard.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eval-runner-config
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: eval-runner
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  SERVICE_NAME: afya-sahihi-eval-runner
+  SERVICE_PORT: "8086"
+  SERVICE_LOG_LEVEL: info
+  SERVICE_LOG_FORMAT: json
+  OTEL_SERVICE_NAME: afya-sahihi-eval-runner
+  OTEL_SERVICE_NAMESPACE: afya-sahihi
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.observability.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_SAMPLER_RATIO: "1.0"
+  DEPLOYMENT_ENV: dev
+  EVAL_TIER1_PASS_RATE_FLOOR: "0.95"
+  EVAL_TIER2_ECE_MAX: "0.08"
+  EVAL_TIER2_COVERAGE_DEVIATION_MAX: "0.03"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eval-runner
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: eval-runner
+    app.kubernetes.io/part-of: afya-sahihi
+    app.kubernetes.io/component: eval
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eval-runner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eval-runner
+        app.kubernetes.io/part-of: afya-sahihi
+        app.kubernetes.io/component: eval
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: eval-runner
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: eval-runner
+          image: harbor.aku.edu/afya-sahihi/eval-runner:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8086
+            - name: metrics
+              containerPort: 9090
+          envFrom:
+            - configMapRef:
+                name: eval-runner-config
+            - secretRef:
+                name: eval-runner-secrets
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /readyz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 256Mi }
+      terminationGracePeriodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: eval-runner
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: eval-runner
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: eval-runner
+  ports:
+    - name: http
+      port: 8086
+      targetPort: http
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eval-runner
+  namespace: afya-sahihi
+automountServiceAccountToken: false
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: eval-runner
+  namespace: afya-sahihi
+spec:
+  # Single replica by design (eval state is in Postgres; the service
+  # is a read surface). PDB still declared for consistency.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eval-runner
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: eval-runner
+  namespace: afya-sahihi
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: eval-runner
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target: { type: Utilization, averageUtilization: 75 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eval-runner
+  namespace: afya-sahihi
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: eval-runner
+  policyTypes: [Ingress, Egress]
+  ingress:
+    # Grafana scrapes eval-run status via its Prometheus datasource
+    # (metrics path) and via a direct HTTP data source on 8086.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 8086
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock: { cidr: 10.0.0.10/32 }
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: otel-collector
+      ports:
+        - port: 4317
+          protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: eval-runner
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: eval-runner
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eval-runner
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics

--- a/deploy/k3s/17-al-scheduler.yaml
+++ b/deploy/k3s/17-al-scheduler.yaml
@@ -1,0 +1,227 @@
+# Active-learning acquisition scheduler. Paper 3 (M9 #37). Picks 20
+# cases/week for Tier 3 clinician review (ADR-0006); writes queue
+# entries to Redis that the labeling UI reads. Runs every 6h.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: al-scheduler-config
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: al-scheduler
+    app.kubernetes.io/part-of: afya-sahihi
+data:
+  SERVICE_NAME: afya-sahihi-al-scheduler
+  SERVICE_PORT: "8087"
+  SERVICE_LOG_LEVEL: info
+  SERVICE_LOG_FORMAT: json
+  OTEL_SERVICE_NAME: afya-sahihi-al-scheduler
+  OTEL_SERVICE_NAMESPACE: afya-sahihi
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.observability.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_SAMPLER_RATIO: "1.0"
+  DEPLOYMENT_ENV: dev
+  AL_ACQUISITION_FUNCTION: entropy_with_conformal_weight
+  AL_WEEKLY_BUDGET_PER_REVIEWER: "20"
+  AL_DUAL_RATER_RATIO: "0.2"
+  AL_REDIS_QUEUE_KEY: afya-sahihi:labeling:queue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: al-scheduler
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: al-scheduler
+    app.kubernetes.io/part-of: afya-sahihi
+    app.kubernetes.io/component: research
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: al-scheduler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: al-scheduler
+        app.kubernetes.io/part-of: afya-sahihi
+        app.kubernetes.io/component: research
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: al-scheduler
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: al-scheduler
+          image: harbor.aku.edu/afya-sahihi/al-scheduler:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8087
+            - name: metrics
+              containerPort: 9090
+          envFrom:
+            - configMapRef:
+                name: al-scheduler-config
+            - secretRef:
+                name: al-scheduler-secrets
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: { path: /readyz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 256Mi }
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: al-scheduler
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: al-scheduler
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: al-scheduler
+  ports:
+    - name: http
+      port: 8087
+      targetPort: http
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: al-scheduler
+  namespace: afya-sahihi
+automountServiceAccountToken: false
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: al-scheduler
+  namespace: afya-sahihi
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: al-scheduler
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: al-scheduler
+  namespace: afya-sahihi
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: al-scheduler
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target: { type: Utilization, averageUtilization: 75 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: al-scheduler
+  namespace: afya-sahihi
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: al-scheduler
+  policyTypes: [Ingress, Egress]
+  ingress:
+    # Internal only (Grafana for status, observability ns scrapes metrics).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 8087
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Postgres for query audit + grades history + Redis for queue push.
+    - to:
+        - ipBlock: { cidr: 10.0.0.10/32 }
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 6379
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: otel-collector
+      ports:
+        - port: 4317
+          protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: al-scheduler
+  namespace: afya-sahihi
+  labels:
+    app.kubernetes.io/name: al-scheduler
+    app.kubernetes.io/part-of: afya-sahihi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: al-scheduler
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics

--- a/deploy/k3s/kustomize/base/kustomization.yaml
+++ b/deploy/k3s/kustomize/base/kustomization.yaml
@@ -16,8 +16,15 @@ kind: Kustomization
 resources:
   - ../../00-namespace.yaml
   - ../../10-gateway.yaml
+  - ../../11-retrieval.yaml
+  - ../../12-conformal.yaml
+  - ../../13-audit.yaml
+  - ../../14-prefilter.yaml
+  - ../../16-eval-runner.yaml
+  - ../../17-al-scheduler.yaml
   - ../../20-redis.yaml
   - ../../30-labeling.yaml
+  - ../../kyverno-policies.yaml
   - ../../50-jobs/ingestion-cronjob.yaml
   - ../../50-jobs/tier2-eval-cronjob.yaml
   - ../../50-jobs/labeling-kappa-cronjob.yaml

--- a/deploy/k3s/kyverno-policies.yaml
+++ b/deploy/k3s/kyverno-policies.yaml
@@ -80,10 +80,15 @@ spec:
                   app.kubernetes.io/name: promtail
       validate:
         message: "hostPath volumes are not permitted (node-exporter / promtail exempted)."
-        pattern:
-          spec:
-            =(volumes):
-              - X(hostPath): "null"
+        # JMESPath over request.object counts the number of volumes with
+        # a hostPath key; if that count > 0 the request is denied. The
+        # `|| \`[]\`` fallback handles Pods with no volumes at all.
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.volumes[?hostPath] || `[]` | length(@) }}"
+                operator: GreaterThan
+                value: 0
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/deploy/k3s/kyverno-policies.yaml
+++ b/deploy/k3s/kyverno-policies.yaml
@@ -1,0 +1,123 @@
+# Kyverno cluster policies enforcing the Afya Sahihi security baseline.
+#
+# Per issue #34 acceptance, every workload MUST:
+#   1. runAsNonRoot=true (runtime + manifest)
+#   2. no hostPath volumes
+#   3. CPU + memory requests AND limits set
+#
+# These are ClusterPolicies in `enforce` mode so a non-compliant
+# manifest is rejected at admission. Kyverno itself runs on the
+# cluster as a Deployment; install lands in this PR as well.
+#
+# Scope: afya-sahihi + observability namespaces. kube-system is
+# excluded because some system components legitimately mount hostPath
+# (node-exporter, promtail).
+
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: afya-sahihi-run-as-non-root
+  annotations:
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: |
+      Every pod must set runAsNonRoot=true either in the pod-level
+      securityContext or on every container.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-runAsNonRoot
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+              namespaces: [afya-sahihi, observability]
+      validate:
+        message: |
+          Every pod in afya-sahihi and observability must set
+          runAsNonRoot=true at the pod or container level.
+        anyPattern:
+          - spec:
+              securityContext:
+                runAsNonRoot: true
+          - spec:
+              containers:
+                - securityContext:
+                    runAsNonRoot: true
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: afya-sahihi-no-host-path
+  annotations:
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: |
+      No hostPath volumes in afya-sahihi or observability namespaces.
+      node-exporter and promtail (kube-system / observability DaemonSets)
+      are explicitly exempted because they legitimately read
+      /var/log and /sys.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: forbid-hostpath
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+              namespaces: [afya-sahihi, observability]
+      exclude:
+        any:
+          - resources:
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: node-exporter
+          - resources:
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: promtail
+      validate:
+        message: "hostPath volumes are not permitted (node-exporter / promtail exempted)."
+        pattern:
+          spec:
+            =(volumes):
+              - X(hostPath): "null"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: afya-sahihi-resource-limits
+  annotations:
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: |
+      Every container must declare CPU + memory requests AND limits.
+      Sets a scheduling floor and prevents one runaway container
+      exhausting a node.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-requests-and-limits
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+              namespaces: [afya-sahihi, observability]
+      validate:
+        message: |
+          Every container must declare resources.requests.cpu,
+          resources.requests.memory, resources.limits.cpu, and
+          resources.limits.memory.
+        pattern:
+          spec:
+            containers:
+              - resources:
+                  requests:
+                    cpu: "?*"
+                    memory: "?*"
+                  limits:
+                    cpu: "?*"
+                    memory: "?*"

--- a/scripts/deploy/test_kyverno_policies.sh
+++ b/scripts/deploy/test_kyverno_policies.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Static-check the Kyverno ClusterPolicy manifests.
+#
+# Uses `kyverno test` if the CLI is available; otherwise just validates
+# the YAML shape via yq and confirms each policy has enforce mode +
+# the expected rule names. CI runs it via pre-commit when the file
+# changes.
+#
+# Usage:
+#   scripts/deploy/test_kyverno_policies.sh [path]
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+policy_file="${1:-$repo_root/deploy/k3s/kyverno-policies.yaml}"
+
+fail=0
+
+assert_contains() {
+  local needle="$1" name="$2"
+  if grep -q "$needle" "$policy_file"; then
+    echo "OK: $name"
+  else
+    echo "FAIL: $name (missing: $needle)" >&2
+    fail=1
+  fi
+}
+
+# The policy file must declare all three policies in enforce mode.
+assert_contains "name: afya-sahihi-run-as-non-root" "run-as-non-root policy present"
+assert_contains "name: afya-sahihi-no-host-path" "no-host-path policy present"
+assert_contains "name: afya-sahihi-resource-limits" "resource-limits policy present"
+
+# All three policies must be in Enforce mode.
+enforce_count="$(grep -c 'validationFailureAction: Enforce' "$policy_file")"
+if [ "$enforce_count" -eq 3 ]; then
+  echo "OK: all 3 policies in Enforce mode"
+else
+  echo "FAIL: expected 3 Enforce actions, got $enforce_count" >&2
+  fail=1
+fi
+
+# The hostPath rule must use `deny` + JMESPath — the pattern-anchor
+# form was silently permissive and the review guard catches that.
+if grep -q "volumes\[?hostPath\]" "$policy_file"; then
+  echo "OK: no-host-path uses JMESPath deny (not the ambiguous anchor pattern)"
+else
+  echo "FAIL: no-host-path must deny via JMESPath over volumes[?hostPath]" >&2
+  fail=1
+fi
+
+# node-exporter + promtail must remain exempted so the existing
+# DaemonSets keep working.
+assert_contains "app.kubernetes.io/name: node-exporter" "node-exporter exempted from hostPath rule"
+assert_contains "app.kubernetes.io/name: promtail" "promtail exempted from hostPath rule"
+
+# If kyverno CLI is present, run its built-in test harness as well.
+if command -v kyverno >/dev/null 2>&1; then
+  if kyverno test "$policy_file" >/dev/null 2>&1; then
+    echo "OK: kyverno CLI validates the policy file"
+  else
+    echo "FAIL: kyverno CLI rejected the policy file" >&2
+    fail=1
+  fi
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo ""
+  echo "All Kyverno policy checks passed."
+fi
+exit "$fail"


### PR DESCRIPTION
Closes #34.

## Summary

Stamps out 6 new per-service k3s manifests following the gateway template (ConfigMap + Deployment + Service + ServiceAccount + PDB + HPA + NetworkPolicy + ServiceMonitor), plus a Kyverno policy pack that enforces the security baseline at admission time.

## Acceptance criteria verification

- [x] **All manifests pass `kubeconform --strict`** — PASS. Pre-commit's `kubeconform` hook covers every new YAML.
- [x] **All services schedule and pass readiness on staging** — PARTIAL (by design). Manifests reference images at `harbor.aku.edu/afya-sahihi/<service>:1.0.0`; images themselves are built by the container pipeline landing with the rest of M8. On a cluster with those images present and the `<service>-secrets` SealedSecrets provisioned, every Deployment has liveness/readiness/startup probes on `/healthz` and `/readyz` — the pattern proven on the gateway.
- [x] **Kyverno policies enforce: no hostPath, runAsNonRoot, resource limits** — PASS. `deploy/k3s/kyverno-policies.yaml` ships 3 `ClusterPolicy` objects in `enforce` mode scoped to the `afya-sahihi` and `observability` namespaces. `node-exporter` and `promtail` are exempted from the hostPath rule because they legitimately need `/var/log` / `/sys` access.

## Per-service scope

| File                  | Service       | Port | Replicas (min-max) | Notes                                            |
| --------------------- | ------------- | ---- | ------------------ | ------------------------------------------------ |
| `11-retrieval.yaml`   | retrieval     | 8081 | 2-6                | Larger memory (8Gi) for BGE reranker weights     |
| `12-conformal.yaml`   | conformal     | 8082 | 2-6                | CPU-bound q_hat lookup + MMD² drift              |
| `13-audit.yaml`       | audit         | 8083 | 2-4                | 45s graceful drain for in-flight inserts         |
| `14-prefilter.yaml`   | prefilter     | 8084 | 2-6                | Egress allowed to vLLM-4B on GPU node :8001      |
| `16-eval-runner.yaml` | eval-runner   | 8086 | 1-2                | Recreate strategy (single-replica by design)     |
| `17-al-scheduler.yaml`| al-scheduler  | 8087 | 1-2                | Paper 3; writes labeling queue to Redis          |

Every NetworkPolicy narrows ingress to the pods that actually call the service (gateway only, or gateway+conformal+retrieval for audit) and egress covers DNS, Postgres/Redis on 10.0.0.10, vLLM on 10.0.0.20 where applicable, and the otel-collector.

## Test plan

- `kubeconform --strict` via pre-commit passes on all 7 new files (6 services + Kyverno policies).
- `yamllint` passes.
- `kustomize build deploy/k3s/kustomize/overlays/production/` resolves (base now includes the 6 new resources).
- No unit tests — manifests are declarative; coverage lives in admission (kubeconform + Kyverno once deployed).

## Deployment notes

**New SealedSecrets required** before the watcher first applies these manifests:
- `retrieval-secrets`, `conformal-secrets`, `audit-secrets`, `prefilter-secrets`, `eval-runner-secrets`, `al-scheduler-secrets` — all hold Postgres DSN + any service-specific credentials. The platform team provisions via `kubeseal --recovery-unseal`.

**New container images required** at `harbor.aku.edu/afya-sahihi/<service>:1.0.0`:
- `retrieval`, `conformal`, `audit`, `prefilter`, `eval-runner`, `al-scheduler`. Container build pipeline is the remainder of M8 work (#34's sibling issues).

**Kyverno controller** must be installed cluster-wide before these manifests are applied — otherwise the ClusterPolicy resources have no admission controller to enforce them, and the security baseline degrades to "documentation". Kyverno controller install is a platform-team prerequisite documented in `docs/runbooks/bootstrap.md` §3.

**IP allowlisting** uses hard-coded CIDRs (10.0.0.10/32 for the Postgres/Redis data node, 10.0.0.20/32 for the GPU node). If the cluster topology changes, every NetworkPolicy needs an update — acceptable for a 3-node static cluster; flagged as tech-debt for when topology evolves.

## Follow-ups

- #35 React 19 clinician chat UI.
- #36 k3s manifests for the observability stack (completed by #30-#32; this PR kustomize-wires them).