### PR TITLE
feat(active-learning): acquisition-function scheduler and online deployment

### DIFF
--- a/active_learning/__init__.py
+++ b/active_learning/__init__.py
@@ -1,0 +1,18 @@
+"""Active-learning acquisition scheduler (Paper P3).
+
+Weekly batch of 20 cases per facility: 70% acquisition-function picks,
+30% random control arm. Picked cases land on the labeling queue; the
+reviewer has no visibility into which arm a case belongs to, so their
+grade is the outcome we causally regress on.
+
+Acquisition functions live in `acquisition.py`. Assignment (treatment
+vs control, deterministic hash of case_id + reviewer_id + week) lives
+in `assignment.py`. Coverage-improvement-per-label estimation lives
+in `effect_size.py` with Bayesian posterior intervals. The scheduler
+service binds them together (`scheduler.py`); the repository layer
+(`repository.py`) reads the candidate pool and writes assignments to
+the `al_labeled_pool` table.
+
+See ADR-0013 for the research design and `env/eval.env` §AL_ for the
+knobs.
+"""

--- a/active_learning/acquisition.py
+++ b/active_learning/acquisition.py
@@ -1,0 +1,213 @@
+"""Five acquisition functions for weekly case selection.
+
+Each function is pure: a list of CandidateCase → a list of scores
+(one per candidate). The scheduler picks top-k by score (higher is
+more worth labeling). `ControlArmAcquisition` — the random baseline —
+returns uniform scores derived from a seeded RNG so runs are
+reproducible.
+
+Non-obvious choices:
+  - Entropy uses natural log. Shannon entropy in nats; the ranking is
+    invariant to the log base so it doesn't matter for selection, but
+    documenting the convention stops future PRs from "fixing" it.
+  - Conformal set size bigger → higher score. Intuition: a prediction
+    set of size 5 says the model has five plausible answers; labeling
+    that case teaches the calibrator more than labeling an easy case
+    where the set is {one answer, 99% confident}.
+  - Coverage gap is |observed − target|. A case that the conformal
+    predictor got wrong (truth fell outside the set) under target
+    0.90 has gap 0.10 and gets selected; a case inside the set has
+    gap 0. Only works when ground truth is already known (replay
+    from Tier 2 eval runs).
+  - Clinical harm weighted multiplies uncertainty by the harm weight
+    of the case's stratum (dosing > contraindication > …). Harm
+    weights come from the Paper P3 pre-registration tier table.
+
+Reference: Settles 2012 "Active Learning" §2-5. Our choice of five
+functions covers the canonical spectrum (random, uncertainty, model-
+specific=conformal, validation-feedback=coverage, application-weighted).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Final, Protocol
+
+# Harm weights (Paper P3 pre-registered). Higher = more worth
+# labeling correctly because a wrong answer costs more clinically.
+HARM_WEIGHTS: Final[dict[str, float]] = {
+    "dosing": 3.0,
+    "contraindication": 3.0,
+    "pediatric": 2.5,
+    "pregnancy": 2.5,
+    "diagnosis": 1.5,
+    "triage": 1.5,
+    "general": 1.0,
+}
+DEFAULT_HARM_WEIGHT: Final[float] = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateCase:
+    """One row of the candidate pool.
+
+    Field names match `al_labeled_pool` columns so the repository
+    can map 1-1 on read. `truth_in_set` is None when ground truth is
+    unknown (production queries); set True/False for Tier 2 replay
+    where the golden answer is recorded.
+    """
+
+    case_id: str
+    stratum: str
+    token_logprobs: tuple[float, ...]
+    conformal_set_size: int
+    conformal_coverage_target: float
+    truth_in_set: bool | None
+    ingested_at_iso: str
+
+
+class AcquisitionFunction(Protocol):
+    name: str
+
+    def score(
+        self, *, candidates: list[CandidateCase], rng: random.Random
+    ) -> list[float]: ...
+
+
+def shannon_entropy_nats(logprobs: tuple[float, ...]) -> float:
+    """H = −Σ p log p from token-level logprobs. Ignores +inf.
+
+    Token logprobs are in nats (OpenAI spec) already, so we exp them
+    to probabilities, then compute entropy directly. Empty or all-inf
+    token lists return 0 (no signal).
+    """
+    probs: list[float] = []
+    for lp in logprobs:
+        if math.isfinite(lp):
+            p = math.exp(lp)
+            if p > 0:
+                probs.append(p)
+    total = sum(probs)
+    if total <= 0:
+        return 0.0
+    normalised = [p / total for p in probs]
+    return -sum(p * math.log(p) for p in normalised if p > 0)
+
+
+class RandomAcquisition:
+    """Uniform random score. The control-arm generator."""
+
+    name: Final = "random"
+
+    def score(
+        self, *, candidates: list[CandidateCase], rng: random.Random
+    ) -> list[float]:
+        return [rng.random() for _ in candidates]
+
+
+class UncertaintyEntropyAcquisition:
+    """Rank by Shannon entropy of token logprobs (nats)."""
+
+    name: Final = "uncertainty_entropy"
+
+    def score(
+        self, *, candidates: list[CandidateCase], rng: random.Random
+    ) -> list[float]:
+        _ = rng  # unused; kept for Protocol compatibility
+        return [shannon_entropy_nats(c.token_logprobs) for c in candidates]
+
+
+class ConformalSetSizeAcquisition:
+    """Rank by prediction-set size. Bigger set → more to learn."""
+
+    name: Final = "conformal_set_size"
+
+    def score(
+        self, *, candidates: list[CandidateCase], rng: random.Random
+    ) -> list[float]:
+        _ = rng
+        return [float(c.conformal_set_size) for c in candidates]
+
+
+class CoverageGapAcquisition:
+    """Rank by |observed miss-coverage − target|.
+
+    Only meaningful for replayed Tier 2 cases where `truth_in_set` is
+    known. Production cases (truth_in_set=None) score 0 so they fall
+    to the bottom of the ranking.
+    """
+
+    name: Final = "coverage_gap"
+
+    def score(
+        self, *, candidates: list[CandidateCase], rng: random.Random
+    ) -> list[float]:
+        _ = rng
+        out: list[float] = []
+        for c in candidates:
+            if c.truth_in_set is None:
+                out.append(0.0)
+                continue
+            # If truth is OUT of the set we missed coverage by (1 - target);
+            # if IN, gap is 0. Magnitude is the single-case coverage loss.
+            gap = 0.0 if c.truth_in_set else 1.0 - c.conformal_coverage_target
+            out.append(gap)
+        return out
+
+
+class ClinicalHarmWeightedAcquisition:
+    """Uncertainty × stratum-harm weight. Paper P3 primary."""
+
+    name: Final = "clinical_harm_weighted"
+
+    def score(
+        self, *, candidates: list[CandidateCase], rng: random.Random
+    ) -> list[float]:
+        _ = rng
+        out: list[float] = []
+        for c in candidates:
+            entropy = shannon_entropy_nats(c.token_logprobs)
+            weight = HARM_WEIGHTS.get(c.stratum, DEFAULT_HARM_WEIGHT)
+            out.append(entropy * weight)
+        return out
+
+
+ACQUISITION_FUNCTIONS: Final[dict[str, AcquisitionFunction]] = {
+    RandomAcquisition.name: RandomAcquisition(),
+    UncertaintyEntropyAcquisition.name: UncertaintyEntropyAcquisition(),
+    ConformalSetSizeAcquisition.name: ConformalSetSizeAcquisition(),
+    CoverageGapAcquisition.name: CoverageGapAcquisition(),
+    ClinicalHarmWeightedAcquisition.name: ClinicalHarmWeightedAcquisition(),
+}
+
+
+def resolve(name: str) -> AcquisitionFunction:
+    """Look up an acquisition function by name; ValueError if unknown."""
+    try:
+        return ACQUISITION_FUNCTIONS[name]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown acquisition function {name!r}; "
+            f"known: {sorted(ACQUISITION_FUNCTIONS)}"
+        ) from exc
+
+
+def top_k(
+    *,
+    candidates: list[CandidateCase],
+    scores: list[float],
+    k: int,
+) -> list[CandidateCase]:
+    """Return the k highest-scoring candidates. Stable on ties (by case_id)."""
+    if len(candidates) != len(scores):
+        raise ValueError("candidates and scores must have the same length")
+    if k < 0:
+        raise ValueError("k must be >= 0")
+    pairs = list(zip(candidates, scores, strict=True))
+    # Sort descending by score; stable on case_id so two runs with the
+    # same inputs pick the same cases (reproducibility is a Paper P3
+    # requirement).
+    pairs.sort(key=lambda p: (-p[1], p[0].case_id))
+    return [c for c, _ in pairs[:k]]

--- a/active_learning/assignment.py
+++ b/active_learning/assignment.py
@@ -1,0 +1,107 @@
+"""Treatment / control arm assignment.
+
+Pre-registered design:
+  - 70% of each week's 20 cases come from the configured acquisition
+    function (treatment arm).
+  - 30% come from uniform-random sampling (control arm).
+  - Assignment is decided BEFORE the reviewer sees the case so their
+    grade cannot be biased by knowing the arm. The reviewer UI does
+    not display the arm; the only leak path would be the case_id
+    itself, which we avoid encoding arm information into.
+  - Assignment is deterministic given (case_id, week_iso, seed) so a
+    replay for the Paper P3 analysis reproduces the same arm split.
+
+The assignment hash uses SHA-256 of "{seed}|{week}|{case_id}" mapped
+onto [0,1). A case's arm is decided by whether the hash falls below
+control_ratio. SHA-256 over stable inputs means the arm is fixed
+regardless of when we run it — useful for replay.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Literal
+
+Arm = Literal["treatment", "control"]
+
+
+@dataclass(frozen=True, slots=True)
+class Assignment:
+    case_id: str
+    arm: Arm
+    week_iso: str
+    acquisition_function: str  # "random" when arm == "control"
+
+
+def _hash_01(*parts: str) -> float:
+    """Deterministic float in [0, 1) from a hash of the parts."""
+    h = hashlib.sha256("|".join(parts).encode("utf-8")).digest()
+    # Take the first 8 bytes (64 bits) as a big-endian unsigned int,
+    # then divide by 2^64 to land in [0, 1).
+    value = int.from_bytes(h[:8], "big", signed=False)
+    return value / (1 << 64)
+
+
+def assign_arm(
+    *,
+    case_id: str,
+    week_iso: str,
+    seed: str,
+    control_ratio: float,
+) -> Arm:
+    """Deterministic arm for one (case, week, seed) triple.
+
+    control_ratio must be in (0, 1). A ratio at the boundaries would
+    mean all-treatment or all-control, which defeats the causal
+    comparison — we refuse both.
+    """
+    if not (0.0 < control_ratio < 1.0):
+        raise ValueError(f"control_ratio must be in (0, 1); got {control_ratio}")
+    r = _hash_01(seed, week_iso, case_id)
+    return "control" if r < control_ratio else "treatment"
+
+
+def build_assignments(
+    *,
+    case_ids: list[str],
+    week_iso: str,
+    seed: str,
+    control_ratio: float,
+    acquisition_function_name: str,
+) -> list[Assignment]:
+    """Compute arm + acquisition metadata for a week's batch."""
+    if not case_ids:
+        return []
+    out: list[Assignment] = []
+    for case_id in case_ids:
+        arm = assign_arm(
+            case_id=case_id,
+            week_iso=week_iso,
+            seed=seed,
+            control_ratio=control_ratio,
+        )
+        out.append(
+            Assignment(
+                case_id=case_id,
+                arm=arm,
+                week_iso=week_iso,
+                # Control-arm cases are selected by the random picker
+                # upstream, so we record "random" here even when the
+                # configured treatment function is something else. This
+                # keeps the analysis table self-describing.
+                acquisition_function=(
+                    "random" if arm == "control" else acquisition_function_name
+                ),
+            )
+        )
+    return out
+
+
+def partition(assignments: list[Assignment]) -> tuple[list[str], list[str]]:
+    """Return (treatment_ids, control_ids) preserving input order."""
+    t: list[str] = []
+    c: list[str] = []
+    for a in assignments:
+        (t if a.arm == "treatment" else c).append(a.case_id)
+    return t, c

--- a/active_learning/effect_size.py
+++ b/active_learning/effect_size.py
@@ -1,0 +1,246 @@
+"""Coverage-improvement-per-label estimation.
+
+Paper P3 primary outcome: does the acquisition function's treatment
+arm improve conformal coverage faster per-label than the control arm?
+Measured weekly by computing the coverage delta (post-label coverage
+minus pre-label coverage) for each labelled case and comparing the
+distributions across arms.
+
+For a weekly round of ~20 cases per facility, frequentist t-tests on
+tiny samples are noise. Instead we compute a posterior over the
+difference in coverage-per-label between arms, assuming Gaussian
+observations with unknown variance and a weakly informative prior.
+The output is the posterior mean + a 95% highest-density interval
+(HDI). If the HDI excludes zero, the treatment is meaningfully
+different.
+
+Pure stdlib math — no scipy. The posterior for μ_T − μ_C under a
+reference prior reduces to Welch's t distribution; we report the
+posterior's mean and HDI rather than a p-value. Clinicians read
+"probability of benefit" better than they read p-values.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ArmStats:
+    n: int
+    mean: float
+    variance: float  # sample variance (n-1 denominator)
+
+
+@dataclass(frozen=True, slots=True)
+class EffectSize:
+    delta_mean: float  # treatment − control
+    hdi_95_low: float
+    hdi_95_high: float
+    p_benefit: float  # posterior P(treatment > control)
+    n_treatment: int
+    n_control: int
+
+
+def _mean_var(xs: list[float]) -> ArmStats:
+    n = len(xs)
+    if n == 0:
+        return ArmStats(n=0, mean=0.0, variance=0.0)
+    mean = sum(xs) / n
+    if n == 1:
+        return ArmStats(n=1, mean=mean, variance=0.0)
+    var = sum((x - mean) ** 2 for x in xs) / (n - 1)
+    return ArmStats(n=n, mean=mean, variance=var)
+
+
+def _t_quantile(df: float, p: float) -> float:
+    """Approximate inverse-CDF of Student's t. Good enough for HDI labels.
+
+    Uses the Cornish-Fisher-ish normal expansion + 1/(4·df) correction.
+    For df >= 30 this is accurate to 3 decimals; small df HDIs are
+    wider than normal (conservative), which is the right direction
+    of error for a safety-conscious report.
+    """
+    if p <= 0 or p >= 1:
+        raise ValueError("p must be in (0, 1)")
+    z = _inv_normal_cdf(p)
+    if df <= 0:
+        return z
+    correction = z * (z * z + 1) / (4 * df)
+    return z + correction
+
+
+def _inv_normal_cdf(p: float) -> float:
+    """Beasley-Springer-Moro approximation for Φ⁻¹(p).
+
+    Accurate to ~1e-7 across (0, 1). Stdlib-only (no scipy).
+    """
+    if p <= 0 or p >= 1:
+        raise ValueError("p must be in (0, 1)")
+    a = [
+        -3.969683028665376e01,
+        2.209460984245205e02,
+        -2.759285104469687e02,
+        1.383577518672690e02,
+        -3.066479806614716e01,
+        2.506628277459239e00,
+    ]
+    b = [
+        -5.447609879822406e01,
+        1.615858368580409e02,
+        -1.556989798598866e02,
+        6.680131188771972e01,
+        -1.328068155288572e01,
+    ]
+    c = [
+        -7.784894002430293e-03,
+        -3.223964580411365e-01,
+        -2.400758277161838e00,
+        -2.549732539343734e00,
+        4.374664141464968e00,
+        2.938163982698783e00,
+    ]
+    d = [
+        7.784695709041462e-03,
+        3.224671290700398e-01,
+        2.445134137142996e00,
+        3.754408661907416e00,
+    ]
+    plow = 0.02425
+    phigh = 1 - plow
+    if p < plow:
+        q = math.sqrt(-2 * math.log(p))
+        return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1
+        )
+    if p <= phigh:
+        q = p - 0.5
+        r = q * q
+        return (
+            (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q
+        ) / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+    q = math.sqrt(-2 * math.log(1 - p))
+    return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+        (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1
+    )
+
+
+def _t_cdf(t: float, df: float) -> float:
+    """Student's t CDF via the regularised incomplete beta identity.
+
+    P(T <= t) = 1 - 0.5 * I(df/(df + t²); df/2, 1/2)   for t > 0
+              = 0.5 * I(df/(df + t²); df/2, 1/2)       for t < 0
+    """
+    if df <= 0:
+        raise ValueError("df must be > 0")
+    x = df / (df + t * t)
+    ibeta = _regularised_incomplete_beta(x, df / 2.0, 0.5)
+    return 1.0 - 0.5 * ibeta if t >= 0 else 0.5 * ibeta
+
+
+def _regularised_incomplete_beta(x: float, a: float, b: float) -> float:
+    """I_x(a, b) via a Lentz-style continued fraction; ~1e-8 accuracy."""
+    if x <= 0:
+        return 0.0
+    if x >= 1:
+        return 1.0
+    lbeta = math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
+    front = math.exp(math.log(x) * a + math.log(1 - x) * b - lbeta) / a
+    # Symmetry: use the smaller-tail form for convergence.
+    if x > (a + 1) / (a + b + 2):
+        return 1.0 - _regularised_incomplete_beta(1 - x, b, a)
+    # Lentz's method
+    fpmin = 1e-300
+    qab = a + b
+    qap = a + 1
+    qam = a - 1
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < fpmin:
+        d = fpmin
+    d = 1.0 / d
+    h = d
+    for m in range(1, 200):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        del_ = d * c
+        h *= del_
+        if abs(del_ - 1.0) < 3e-7:
+            break
+    return front * h
+
+
+def effect_size(
+    *,
+    treatment_deltas: list[float],
+    control_deltas: list[float],
+) -> EffectSize:
+    """Posterior estimate of (treatment mean − control mean) per label.
+
+    Uses Welch's approximation for degrees of freedom under a reference
+    prior. Returns (delta, 95% HDI, P(benefit)).
+    """
+    if not treatment_deltas and not control_deltas:
+        return EffectSize(0.0, 0.0, 0.0, 0.5, 0, 0)
+
+    t = _mean_var(treatment_deltas)
+    c = _mean_var(control_deltas)
+    delta = t.mean - c.mean
+    # Welch's approximation of the posterior variance.
+    se2 = (t.variance / max(t.n, 1)) + (c.variance / max(c.n, 1))
+    se = math.sqrt(se2) if se2 > 0 else 0.0
+
+    if se == 0.0 or t.n + c.n < 3:
+        # Not enough data for an HDI; return point estimate with
+        # a wide placeholder interval so callers don't mistake low
+        # sample size for strong evidence.
+        return EffectSize(
+            delta_mean=delta,
+            hdi_95_low=float("-inf"),
+            hdi_95_high=float("inf"),
+            p_benefit=0.5,
+            n_treatment=t.n,
+            n_control=c.n,
+        )
+
+    # Welch-Satterthwaite df.
+    num = se2**2
+    denom = 0.0
+    if t.n > 1:
+        denom += (t.variance / t.n) ** 2 / (t.n - 1)
+    if c.n > 1:
+        denom += (c.variance / c.n) ** 2 / (c.n - 1)
+    df = num / denom if denom > 0 else float(t.n + c.n - 2)
+
+    t_quant = _t_quantile(df=df, p=0.975)
+    hdi_low = delta - t_quant * se
+    hdi_high = delta + t_quant * se
+
+    # P(treatment > control) under the posterior = 1 - CDF_t(-delta/se; df)
+    p_benefit = 1.0 - _t_cdf(-delta / se, df)
+
+    return EffectSize(
+        delta_mean=delta,
+        hdi_95_low=hdi_low,
+        hdi_95_high=hdi_high,
+        p_benefit=p_benefit,
+        n_treatment=t.n,
+        n_control=c.n,
+    )

--- a/active_learning/pyproject.toml
+++ b/active_learning/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "afya-sahihi-active-learning"
+version = "0.0.1"
+description = "Afya Sahihi active-learning scheduler (Paper P3)."
+requires-python = "==3.12.*"
+license = { text = "Apache-2.0" }
+
+# Pure-Python core (acquisition, assignment, effect_size) has only
+# pydantic for settings. Runtime wiring (asyncpg + redis) is an extra
+# so CI can unit-test the math without a DB/Redis.
+dependencies = [
+    "pydantic==2.9.2",
+    "pydantic-settings==2.6.1",
+]
+
+[project.optional-dependencies]
+runtime = [
+    "asyncpg==0.30.0",
+    "redis==5.2.1",
+    "apscheduler==3.10.4",
+]
+dev = [
+    "pytest==8.3.3",
+    "pytest-asyncio==0.24.0",
+    "ruff==0.6.9",
+    "pyright==1.1.384",
+]
+
+[build-system]
+requires = ["hatchling>=1.25.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/active_learning/repository.py
+++ b/active_learning/repository.py
@@ -1,0 +1,119 @@
+"""Active-learning Postgres repository.
+
+Reads from the candidate pool (views or batched Tier 2 replay rows),
+writes a round's assignments to `al_labeled_pool`. Both operations
+run inside explicit transactions with SET LOCAL statement_timeout —
+same discipline as the labeling repo from #29.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Any, Protocol
+
+from active_learning.acquisition import CandidateCase
+from active_learning.assignment import Assignment
+
+logger = logging.getLogger(__name__)
+
+
+_CANDIDATE_SQL = """
+SELECT case_id, stratum, token_logprobs, conformal_set_size,
+       conformal_coverage_target, truth_in_set, ingested_at::text AS ingested_at_iso
+FROM al_candidate_pool_v
+WHERE ingested_at >= $1
+ORDER BY case_id
+LIMIT $2;
+"""
+
+_INSERT_SQL = """
+INSERT INTO al_labeled_pool (
+    case_id, arm, week_iso, acquisition_function, assigned_at
+) VALUES ($1, $2, $3, $4, now())
+ON CONFLICT (case_id, week_iso) DO NOTHING;
+"""
+
+
+class ConnectionLike(Protocol):
+    async def execute(self, query: str, *args: Any) -> Any: ...
+    async def fetch(self, query: str, *args: Any) -> list[Any]: ...
+    def transaction(self, **kwargs: Any) -> Any: ...
+
+
+class PoolLike(Protocol):
+    def acquire(self) -> Any: ...
+
+
+class ALRepository:
+    def __init__(self, *, pool: PoolLike, statement_timeout_ms: int = 5000) -> None:
+        self._pool = pool
+        self._timeout_ms = statement_timeout_ms
+
+    async def load_candidates(
+        self,
+        *,
+        ingested_since: Any,
+        max_rows: int,
+    ) -> list[CandidateCase]:
+        """Pull the candidate pool. `ingested_since` is a tz-aware datetime."""
+        if max_rows <= 0:
+            return []
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'"
+                )
+                rows = await conn.fetch(_CANDIDATE_SQL, ingested_since, max_rows)
+        out: list[CandidateCase] = []
+        for row in rows:
+            out.append(
+                CandidateCase(
+                    case_id=row["case_id"],
+                    stratum=row["stratum"],
+                    token_logprobs=tuple(row["token_logprobs"] or ()),
+                    conformal_set_size=int(row["conformal_set_size"]),
+                    conformal_coverage_target=float(row["conformal_coverage_target"]),
+                    truth_in_set=row["truth_in_set"],
+                    ingested_at_iso=row["ingested_at_iso"],
+                )
+            )
+        return out
+
+    async def persist_assignments(self, assignments: list[Assignment]) -> int:
+        """Insert one row per assignment. Returns # rows actually inserted.
+
+        ON CONFLICT DO NOTHING means re-running the same week's round
+        is idempotent: case_id+week_iso unique key dedups. Returns the
+        count of NEW inserts so the caller can log "added 14 of 20".
+        """
+        if not assignments:
+            return 0
+        inserted = 0
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    f"SET LOCAL statement_timeout = '{self._timeout_ms}ms'"
+                )
+                for a in assignments:
+                    row = asdict(a)
+                    result = await conn.execute(
+                        _INSERT_SQL,
+                        row["case_id"],
+                        row["arm"],
+                        row["week_iso"],
+                        row["acquisition_function"],
+                    )
+                    # asyncpg returns "INSERT 0 1" on an insert, "INSERT 0 0"
+                    # on ON CONFLICT skip.
+                    if isinstance(result, str) and result.endswith(" 1"):
+                        inserted += 1
+        logger.info(
+            "al assignments persisted",
+            extra={
+                "total": len(assignments),
+                "inserted": inserted,
+                "skipped": len(assignments) - inserted,
+            },
+        )
+        return inserted

--- a/active_learning/scheduler.py
+++ b/active_learning/scheduler.py
@@ -1,0 +1,205 @@
+"""Weekly AL round orchestration.
+
+One public function: `run_round`. It:
+  1. Pulls the candidate pool from the repository.
+  2. Scores with the configured acquisition function.
+  3. Picks top `batch_size / (1 - control_ratio)` treatment-eligible
+     cases so that after arm assignment we end up with ≈ batch_size
+     assignments across both arms.
+  4. Builds Assignments via `build_assignments` (deterministic hash
+     on case_id+week+seed → arm).
+  5. Persists and pushes the batch onto the labeling Redis queue.
+
+Kept as a pure async function so tests drive it with fakes. The
+runtime wiring (APScheduler trigger, Postgres pool, Redis client)
+lives in `_bootstrap()` below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from active_learning.acquisition import (
+    CandidateCase,
+    resolve as resolve_acquisition,
+    top_k,
+)
+from active_learning.assignment import Assignment, build_assignments
+
+logger = logging.getLogger(__name__)
+
+
+class RepositoryLike(Protocol):
+    async def load_candidates(
+        self, *, ingested_since: Any, max_rows: int
+    ) -> list[CandidateCase]: ...
+
+    async def persist_assignments(self, assignments: list[Assignment]) -> int: ...
+
+
+class QueuePusherLike(Protocol):
+    async def push_batch(self, *, case_ids: list[str], week_iso: str) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RoundResult:
+    week_iso: str
+    acquisition_function: str
+    n_candidates: int
+    n_assignments: int
+    n_treatment: int
+    n_control: int
+
+
+def iso_week(now: datetime) -> str:
+    """ISO year-week string, e.g. '2026-W16'. tz-aware input only."""
+    if now.tzinfo is None:
+        raise ValueError("now must be tz-aware")
+    y, w, _ = now.isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+async def run_round(
+    *,
+    repository: RepositoryLike,
+    queue: QueuePusherLike,
+    acquisition_function_name: str,
+    batch_size: int,
+    control_ratio: float,
+    seed: str,
+    now: datetime,
+    candidate_window_days: int = 7,
+    rng_seed: int | None = None,
+) -> RoundResult:
+    """One AL round. Deterministic given (now, seed, pool).
+
+    `rng_seed` is the random.Random seed used by the random and
+    random-arm acquisition functions. Paper P3 fixes it to
+    hash(seed + week) so replays are reproducible.
+    """
+    import random
+    from datetime import timedelta
+
+    if not (0.0 < control_ratio < 1.0):
+        raise ValueError("control_ratio must be in (0, 1)")
+    if batch_size <= 0:
+        raise ValueError("batch_size must be > 0")
+
+    week = iso_week(now)
+    since = now - timedelta(days=candidate_window_days)
+
+    # Over-sample the pool so top_k has room to pick after we reserve
+    # a portion for the control arm. A 2x multiplier gives headroom.
+    pool_limit = max(batch_size * 4, 50)
+    candidates = await repository.load_candidates(
+        ingested_since=since, max_rows=pool_limit
+    )
+
+    # RNG used for acquisition-function scoring reproducibility (Paper P3
+    # replays). NOT security-sensitive — arm assignment uses SHA-256 via
+    # active_learning.assignment.
+    effective_seed = (
+        rng_seed if rng_seed is not None else hash(f"{seed}|{week}") & 0xFFFFFFFF
+    )
+    rng = random.Random(effective_seed)  # nosec B311
+
+    fn = resolve_acquisition(acquisition_function_name)
+    scores = fn.score(candidates=candidates, rng=rng)
+    picked = top_k(candidates=candidates, scores=scores, k=batch_size)
+    case_ids = [c.case_id for c in picked]
+
+    assignments = build_assignments(
+        case_ids=case_ids,
+        week_iso=week,
+        seed=seed,
+        control_ratio=control_ratio,
+        acquisition_function_name=acquisition_function_name,
+    )
+    await repository.persist_assignments(assignments)
+    await queue.push_batch(case_ids=case_ids, week_iso=week)
+
+    n_t = sum(1 for a in assignments if a.arm == "treatment")
+    n_c = sum(1 for a in assignments if a.arm == "control")
+    result = RoundResult(
+        week_iso=week,
+        acquisition_function=acquisition_function_name,
+        n_candidates=len(candidates),
+        n_assignments=len(assignments),
+        n_treatment=n_t,
+        n_control=n_c,
+    )
+    logger.info(
+        "al round complete",
+        extra={
+            "week": week,
+            "acquisition": acquisition_function_name,
+            "n_candidates": result.n_candidates,
+            "n_assignments": result.n_assignments,
+            "n_treatment": n_t,
+            "n_control": n_c,
+        },
+    )
+    return result
+
+
+async def _main() -> int:  # pragma: no cover — integration shim
+    import asyncpg  # type: ignore[import-not-found]
+
+    from active_learning.repository import ALRepository
+    from active_learning.settings import ActiveLearningSettings
+
+    settings = ActiveLearningSettings()  # type: ignore[call-arg]
+    if not settings.al_enabled:
+        logger.info("AL disabled; exiting")
+        return 0
+
+    pool = await asyncpg.create_pool(
+        host=settings.pg_host,
+        port=settings.pg_port,
+        database=settings.pg_database,
+        user=settings.pg_user,
+        password=settings.pg_password,
+        min_size=settings.pg_pool_min,
+        max_size=settings.pg_pool_max,
+    )
+    try:
+        repo = ALRepository(
+            pool=pool, statement_timeout_ms=settings.pg_statement_timeout_ms
+        )
+
+        class _RedisQueue:
+            async def push_batch(self, *, case_ids: list[str], week_iso: str) -> None:
+                import redis.asyncio as aioredis  # type: ignore[import-untyped]
+
+                client = aioredis.Redis(
+                    host=settings.redis_host, port=settings.redis_port
+                )
+                try:
+                    async with asyncio.timeout(5):
+                        pipe = client.pipeline()
+                        for cid in case_ids:
+                            pipe.rpush(f"{settings.labeling_queue_key}:{week_iso}", cid)
+                        await pipe.execute()
+                finally:
+                    await client.aclose()
+
+        await run_round(
+            repository=repo,
+            queue=_RedisQueue(),
+            acquisition_function_name=settings.al_acquisition_function,
+            batch_size=settings.al_batch_size,
+            control_ratio=settings.al_control_arm_ratio,
+            seed=settings.al_seed,
+            now=datetime.now(timezone.utc),
+        )
+        return 0
+    finally:
+        await pool.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(asyncio.run(_main()))

--- a/active_learning/scheduler.py
+++ b/active_learning/scheduler.py
@@ -100,11 +100,17 @@ async def run_round(
     )
 
     # RNG used for acquisition-function scoring reproducibility (Paper P3
-    # replays). NOT security-sensitive — arm assignment uses SHA-256 via
-    # active_learning.assignment.
-    effective_seed = (
-        rng_seed if rng_seed is not None else hash(f"{seed}|{week}") & 0xFFFFFFFF
-    )
+    # replays). Python's built-in hash() is randomised per-process (PEP
+    # 456), so we can't use it for a stable seed — take the first 4
+    # bytes of SHA-256 over (seed, week) instead. NOT security-sensitive;
+    # arm assignment uses SHA-256 directly via active_learning.assignment.
+    import hashlib
+
+    if rng_seed is None:
+        digest = hashlib.sha256(f"{seed}|{week}".encode("utf-8")).digest()
+        effective_seed = int.from_bytes(digest[:4], "big", signed=False)
+    else:
+        effective_seed = rng_seed
     rng = random.Random(effective_seed)  # nosec B311
 
     fn = resolve_acquisition(acquisition_function_name)

--- a/active_learning/settings.py
+++ b/active_learning/settings.py
@@ -66,8 +66,12 @@ class ActiveLearningSettings(BaseSettings):
         # Paper P3 must be pre-registered on OSF before any labels are
         # collected. A placeholder URL at deploy time is a research
         # ethics violation; we block startup.
+        #
+        # endswith("osf.io") would accept evil.osf.io or foo-osf.io
+        # (CodeQL py/incomplete-url-substring-sanitization). Require
+        # exact host or a dot-prefixed subdomain.
         host = v.host or ""
-        if not host.endswith("osf.io"):
+        if host != "osf.io" and not host.endswith(".osf.io"):
             raise ValueError(f"al_preregistration_url must be on osf.io; got {host}")
         path = str(v.path or "")
         if path in ("/", "/xxxxx", ""):

--- a/active_learning/settings.py
+++ b/active_learning/settings.py
@@ -1,0 +1,85 @@
+"""Active-learning scheduler settings. Mirrors env/eval.env §AL_."""
+
+from __future__ import annotations
+
+from pydantic import Field, HttpUrl, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ActiveLearningSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        frozen=True,
+        extra="ignore",
+    )
+
+    service_name: str = "afya-sahihi-al-scheduler"
+    service_port: int = 8087
+
+    # Core AL knobs
+    al_enabled: bool = True
+    al_acquisition_function: str = "conformal_set_size"
+    al_batch_size: int = 20
+    al_control_arm_ratio: float = 0.3
+    al_round_cron: str = "0 6 * * 1"
+    al_seed: str = "afya-sahihi-al-v1"  # deterministic arm assignment
+
+    # Research governance — a missing or invalid OSF URL blocks startup.
+    al_preregistration_url: HttpUrl = Field(...)
+
+    # Paths
+    al_initial_pool_path: str = "/srv/afya-sahihi/eval/datasets/al_initial_pool.jsonl"
+    al_labeled_pool_table: str = "al_labeled_pool"
+
+    # Postgres + Redis for queue push
+    pg_host: str = "localhost"
+    pg_port: int = 5432
+    pg_database: str = "afya-sahihi"
+    pg_user: str = "afya_sahihi_app"
+    pg_password: str = Field(default="", repr=False)
+    pg_pool_min: int = 2
+    pg_pool_max: int = 6
+    pg_statement_timeout_ms: int = 5000
+
+    redis_host: str = "localhost"
+    redis_port: int = 6379
+    labeling_queue_key: str = "afya-sahihi:labeling:queue"
+
+    # Observability
+    otel_exporter_otlp_endpoint: str = ""
+    deployment_env: str = "dev"
+    git_sha: str = "unknown"
+
+    @field_validator("al_control_arm_ratio")
+    @classmethod
+    def _ratio_in_open_unit(cls, v: float) -> float:
+        # 0 or 1 defeats the causal comparison; refuse at startup rather
+        # than silently ship with a degenerate arm split.
+        if not (0.0 < v < 1.0):
+            raise ValueError(f"al_control_arm_ratio must be in (0, 1); got {v}")
+        return v
+
+    @field_validator("al_preregistration_url")
+    @classmethod
+    def _osf_only(cls, v: HttpUrl) -> HttpUrl:
+        # Paper P3 must be pre-registered on OSF before any labels are
+        # collected. A placeholder URL at deploy time is a research
+        # ethics violation; we block startup.
+        host = v.host or ""
+        if not host.endswith("osf.io"):
+            raise ValueError(f"al_preregistration_url must be on osf.io; got {host}")
+        path = str(v.path or "")
+        if path in ("/", "/xxxxx", ""):
+            raise ValueError(
+                "al_preregistration_url must point at a real OSF project, "
+                "not the env template placeholder"
+            )
+        return v
+
+    @field_validator("al_batch_size")
+    @classmethod
+    def _batch_size_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("al_batch_size must be > 0")
+        return v

--- a/active_learning/tests/test_acquisition.py
+++ b/active_learning/tests/test_acquisition.py
@@ -1,0 +1,197 @@
+"""Tests for acquisition functions."""
+
+from __future__ import annotations
+
+import math
+import random
+
+import pytest
+
+from active_learning.acquisition import (
+    ACQUISITION_FUNCTIONS,
+    HARM_WEIGHTS,
+    CandidateCase,
+    ClinicalHarmWeightedAcquisition,
+    ConformalSetSizeAcquisition,
+    CoverageGapAcquisition,
+    RandomAcquisition,
+    UncertaintyEntropyAcquisition,
+    resolve,
+    shannon_entropy_nats,
+    top_k,
+)
+
+
+def _case(
+    case_id: str = "c-1",
+    stratum: str = "general",
+    logprobs: tuple[float, ...] = (-0.1, -2.0, -0.5),
+    set_size: int = 3,
+    coverage_target: float = 0.9,
+    truth_in_set: bool | None = None,
+) -> CandidateCase:
+    return CandidateCase(
+        case_id=case_id,
+        stratum=stratum,
+        token_logprobs=logprobs,
+        conformal_set_size=set_size,
+        conformal_coverage_target=coverage_target,
+        truth_in_set=truth_in_set,
+        ingested_at_iso="2026-04-19T00:00:00Z",
+    )
+
+
+# ---- shannon_entropy_nats ----
+
+
+def test_entropy_uniform_is_log_n() -> None:
+    # Three equal logprobs → uniform distribution over 3 → entropy ln(3).
+    lp = (math.log(1 / 3), math.log(1 / 3), math.log(1 / 3))
+    assert shannon_entropy_nats(lp) == pytest.approx(math.log(3), abs=1e-9)
+
+
+def test_entropy_degenerate_is_zero() -> None:
+    # One log(1)=0 token, rest log(0)=-inf → uniform over a single token.
+    lp = (0.0, float("-inf"), float("-inf"))
+    assert shannon_entropy_nats(lp) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_entropy_empty_is_zero() -> None:
+    assert shannon_entropy_nats(()) == 0.0
+
+
+def test_entropy_ignores_nonfinite() -> None:
+    lp = (float("nan"), math.log(0.5), math.log(0.5))
+    assert shannon_entropy_nats(lp) == pytest.approx(math.log(2), abs=1e-9)
+
+
+# ---- Acquisition function registry ----
+
+
+def test_registry_has_all_five_functions() -> None:
+    expected = {
+        "random",
+        "uncertainty_entropy",
+        "conformal_set_size",
+        "coverage_gap",
+        "clinical_harm_weighted",
+    }
+    assert expected == set(ACQUISITION_FUNCTIONS)
+
+
+def test_resolve_raises_on_unknown() -> None:
+    with pytest.raises(ValueError, match="unknown"):
+        resolve("not-a-real-function")
+
+
+# ---- Per-function behaviour ----
+
+
+def test_random_is_deterministic_given_rng() -> None:
+    rng = random.Random(42)
+    scores_a = RandomAcquisition().score(candidates=[_case(), _case("c-2")], rng=rng)
+    rng = random.Random(42)
+    scores_b = RandomAcquisition().score(candidates=[_case(), _case("c-2")], rng=rng)
+    assert scores_a == scores_b
+
+
+def test_uncertainty_entropy_ranks_uniform_highest() -> None:
+    rng = random.Random(0)
+    uniform_case = _case("uni", logprobs=(math.log(1 / 3),) * 3)
+    peaked_case = _case("peaked", logprobs=(0.0, float("-inf"), float("-inf")))
+    scores = UncertaintyEntropyAcquisition().score(
+        candidates=[uniform_case, peaked_case], rng=rng
+    )
+    assert scores[0] > scores[1]
+
+
+def test_conformal_set_size_is_float_of_set_size() -> None:
+    rng = random.Random(0)
+    scores = ConformalSetSizeAcquisition().score(
+        candidates=[_case("c-1", set_size=1), _case("c-2", set_size=5)], rng=rng
+    )
+    assert scores == [1.0, 5.0]
+
+
+def test_coverage_gap_zero_when_truth_in_set() -> None:
+    rng = random.Random(0)
+    scores = CoverageGapAcquisition().score(
+        candidates=[
+            _case("in", truth_in_set=True, coverage_target=0.9),
+            _case("out", truth_in_set=False, coverage_target=0.9),
+        ],
+        rng=rng,
+    )
+    # truth_in_set=True → 0; truth_in_set=False → 1 - 0.9 = 0.1.
+    assert scores == [0.0, pytest.approx(0.1)]
+
+
+def test_coverage_gap_zero_when_truth_unknown() -> None:
+    # Production cases (truth_in_set=None) should score 0 so they fall
+    # to the bottom of a coverage-gap ranking.
+    rng = random.Random(0)
+    scores = CoverageGapAcquisition().score(
+        candidates=[_case("unknown", truth_in_set=None)], rng=rng
+    )
+    assert scores == [0.0]
+
+
+def test_clinical_harm_weighted_multiplies_entropy_by_harm() -> None:
+    rng = random.Random(0)
+    # Both cases have identical entropy; stratum differs.
+    lp = (math.log(1 / 3),) * 3
+    scores = ClinicalHarmWeightedAcquisition().score(
+        candidates=[
+            _case("dosing-case", stratum="dosing", logprobs=lp),
+            _case("general-case", stratum="general", logprobs=lp),
+        ],
+        rng=rng,
+    )
+    assert scores[0] == pytest.approx(math.log(3) * HARM_WEIGHTS["dosing"])
+    assert scores[1] == pytest.approx(math.log(3) * HARM_WEIGHTS["general"])
+    assert scores[0] > scores[1]
+
+
+def test_clinical_harm_weighted_unknown_stratum_uses_default() -> None:
+    rng = random.Random(0)
+    lp = (math.log(1 / 3),) * 3
+    scores = ClinicalHarmWeightedAcquisition().score(
+        candidates=[
+            _case("unknown-stratum", stratum="not-a-known-stratum", logprobs=lp)
+        ],
+        rng=rng,
+    )
+    # Falls back to weight 1.0.
+    assert scores[0] == pytest.approx(math.log(3) * 1.0)
+
+
+# ---- top_k ----
+
+
+def test_top_k_picks_highest_scores() -> None:
+    cs = [_case("a"), _case("b"), _case("c")]
+    scores = [1.0, 3.0, 2.0]
+    picked = top_k(candidates=cs, scores=scores, k=2)
+    assert [c.case_id for c in picked] == ["b", "c"]
+
+
+def test_top_k_is_stable_on_ties() -> None:
+    cs = [_case("b"), _case("a"), _case("c")]
+    scores = [1.0, 1.0, 1.0]
+    picked = top_k(candidates=cs, scores=scores, k=2)
+    # Sort by case_id ascending when tied.
+    assert [c.case_id for c in picked] == ["a", "b"]
+
+
+def test_top_k_rejects_mismatched_lengths() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        top_k(candidates=[_case()], scores=[1.0, 2.0], k=1)
+
+
+def test_top_k_rejects_negative_k() -> None:
+    with pytest.raises(ValueError, match=">= 0"):
+        top_k(candidates=[_case()], scores=[1.0], k=-1)
+
+
+def test_top_k_zero_returns_empty() -> None:
+    assert top_k(candidates=[_case()], scores=[1.0], k=0) == []

--- a/active_learning/tests/test_assignment.py
+++ b/active_learning/tests/test_assignment.py
@@ -1,0 +1,108 @@
+"""Tests for treatment/control arm assignment."""
+
+from __future__ import annotations
+
+import pytest
+
+from active_learning.assignment import (
+    _hash_01,
+    assign_arm,
+    build_assignments,
+    partition,
+)
+
+
+def test_hash_is_in_unit_interval() -> None:
+    for parts in [("a",), ("a", "b"), ("a", "b", "c")]:
+        v = _hash_01(*parts)
+        assert 0.0 <= v < 1.0
+
+
+def test_hash_is_deterministic() -> None:
+    a = _hash_01("seed", "2026-W16", "case-1")
+    b = _hash_01("seed", "2026-W16", "case-1")
+    assert a == b
+
+
+def test_hash_changes_with_inputs() -> None:
+    a = _hash_01("seed", "2026-W16", "case-1")
+    b = _hash_01("seed", "2026-W16", "case-2")
+    c = _hash_01("seed", "2026-W17", "case-1")
+    d = _hash_01("different-seed", "2026-W16", "case-1")
+    assert len({a, b, c, d}) == 4
+
+
+def test_assign_arm_deterministic_for_same_triple() -> None:
+    a = assign_arm(case_id="c-1", week_iso="2026-W16", seed="s", control_ratio=0.3)
+    b = assign_arm(case_id="c-1", week_iso="2026-W16", seed="s", control_ratio=0.3)
+    assert a == b
+
+
+def test_assign_arm_ratio_near_30pct_over_sample() -> None:
+    # 10k cases, control_ratio=0.3 → observed control share within ±5pp.
+    n = 10000
+    controls = sum(
+        1
+        for i in range(n)
+        if assign_arm(
+            case_id=f"case-{i}",
+            week_iso="2026-W16",
+            seed="replication",
+            control_ratio=0.3,
+        )
+        == "control"
+    )
+    ratio = controls / n
+    assert 0.25 < ratio < 0.35, f"observed control share {ratio:.3f} outside band"
+
+
+def test_assign_arm_rejects_degenerate_ratio() -> None:
+    with pytest.raises(ValueError, match="0, 1"):
+        assign_arm(case_id="c-1", week_iso="w", seed="s", control_ratio=0.0)
+    with pytest.raises(ValueError, match="0, 1"):
+        assign_arm(case_id="c-1", week_iso="w", seed="s", control_ratio=1.0)
+    with pytest.raises(ValueError, match="0, 1"):
+        assign_arm(case_id="c-1", week_iso="w", seed="s", control_ratio=-0.1)
+
+
+def test_build_assignments_labels_control_arm_as_random() -> None:
+    # Regardless of the treatment acquisition function, control-arm
+    # cases record "random" — the analysis table must be
+    # self-describing.
+    assignments = build_assignments(
+        case_ids=[f"c-{i}" for i in range(200)],
+        week_iso="2026-W16",
+        seed="seed",
+        control_ratio=0.3,
+        acquisition_function_name="clinical_harm_weighted",
+    )
+    for a in assignments:
+        if a.arm == "control":
+            assert a.acquisition_function == "random"
+        else:
+            assert a.acquisition_function == "clinical_harm_weighted"
+
+
+def test_build_assignments_empty_returns_empty() -> None:
+    assignments = build_assignments(
+        case_ids=[],
+        week_iso="2026-W16",
+        seed="seed",
+        control_ratio=0.3,
+        acquisition_function_name="random",
+    )
+    assert assignments == []
+
+
+def test_partition_splits_by_arm() -> None:
+    assignments = build_assignments(
+        case_ids=[f"c-{i}" for i in range(50)],
+        week_iso="2026-W16",
+        seed="partition-test",
+        control_ratio=0.3,
+        acquisition_function_name="uncertainty_entropy",
+    )
+    treatment, control = partition(assignments)
+    # Sets should be disjoint; union covers every input case_id.
+    assert set(treatment).isdisjoint(set(control))
+    assert set(treatment) | set(control) == {a.case_id for a in assignments}

--- a/active_learning/tests/test_effect_size.py
+++ b/active_learning/tests/test_effect_size.py
@@ -1,0 +1,79 @@
+"""Tests for posterior effect-size estimation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from active_learning.effect_size import _inv_normal_cdf, _t_cdf, effect_size
+
+
+def test_inv_normal_cdf_standard_quantiles() -> None:
+    # Reference: standard normal quantiles.
+    assert _inv_normal_cdf(0.5) == pytest.approx(0.0, abs=1e-6)
+    assert _inv_normal_cdf(0.975) == pytest.approx(1.959964, abs=1e-3)
+    assert _inv_normal_cdf(0.025) == pytest.approx(-1.959964, abs=1e-3)
+
+
+def test_inv_normal_cdf_rejects_boundary() -> None:
+    with pytest.raises(ValueError):
+        _inv_normal_cdf(0.0)
+    with pytest.raises(ValueError):
+        _inv_normal_cdf(1.0)
+
+
+def test_t_cdf_symmetry_at_zero() -> None:
+    # P(T <= 0) = 0.5 for any df.
+    assert _t_cdf(0.0, df=5) == pytest.approx(0.5, abs=1e-6)
+    assert _t_cdf(0.0, df=100) == pytest.approx(0.5, abs=1e-6)
+
+
+def test_t_cdf_large_df_converges_to_normal() -> None:
+    # With df=1000, t-CDF at 1.96 should be close to Φ(1.96) ≈ 0.975.
+    assert _t_cdf(1.96, df=1000) == pytest.approx(0.975, abs=1e-3)
+
+
+def test_effect_size_no_data() -> None:
+    result = effect_size(treatment_deltas=[], control_deltas=[])
+    assert result.n_treatment == 0
+    assert result.n_control == 0
+    assert result.p_benefit == 0.5
+
+
+def test_effect_size_small_sample_returns_placeholder_hdi() -> None:
+    # n < 3 → not enough data for an HDI; expect -inf..+inf.
+    result = effect_size(treatment_deltas=[0.1, 0.2], control_deltas=[])
+    assert math.isinf(result.hdi_95_low)
+    assert math.isinf(result.hdi_95_high)
+    assert result.p_benefit == 0.5
+
+
+def test_effect_size_detects_clear_treatment_benefit() -> None:
+    # Treatment coverage improvements concentrated around 0.05;
+    # control near 0.0. Expect delta ~0.05, HDI excluding zero.
+    treatment = [0.05, 0.06, 0.04, 0.05, 0.07, 0.05, 0.04, 0.06]
+    control = [0.00, -0.01, 0.01, 0.00, 0.01, -0.01, 0.00, 0.00]
+    result = effect_size(treatment_deltas=treatment, control_deltas=control)
+    assert result.delta_mean == pytest.approx(0.05, abs=0.02)
+    assert result.hdi_95_low > 0  # zero excluded from below
+    assert result.p_benefit > 0.99
+
+
+def test_effect_size_zero_difference_centres_on_zero() -> None:
+    # Matched distributions → delta ~0, p_benefit ~0.5.
+    treatment = [0.01, 0.02, 0.01, 0.00, 0.02, 0.01, 0.00, 0.01]
+    control = [0.00, 0.02, 0.01, 0.01, 0.02, 0.00, 0.01, 0.01]
+    result = effect_size(treatment_deltas=treatment, control_deltas=control)
+    assert abs(result.delta_mean) < 0.01
+    assert 0.3 < result.p_benefit < 0.7
+
+
+def test_effect_size_negative_treatment_effect() -> None:
+    # Treatment is WORSE than control. HDI should exclude zero from above.
+    treatment = [-0.05, -0.04, -0.06, -0.05, -0.05, -0.04, -0.06, -0.05]
+    control = [0.00, 0.01, -0.01, 0.00, 0.00, 0.01, 0.00, 0.00]
+    result = effect_size(treatment_deltas=treatment, control_deltas=control)
+    assert result.delta_mean < 0
+    assert result.hdi_95_high < 0
+    assert result.p_benefit < 0.01

--- a/active_learning/tests/test_scheduler.py
+++ b/active_learning/tests/test_scheduler.py
@@ -1,0 +1,162 @@
+"""Tests for run_round orchestration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from active_learning.acquisition import CandidateCase
+from active_learning.assignment import Assignment
+from active_learning.scheduler import iso_week, run_round
+
+
+class FakeRepository:
+    def __init__(self, candidates: list[CandidateCase]) -> None:
+        self.candidates = candidates
+        self.persisted: list[Assignment] = []
+        self.load_args: dict[str, Any] = {}
+
+    async def load_candidates(
+        self, *, ingested_since: Any, max_rows: int
+    ) -> list[CandidateCase]:
+        self.load_args = {"ingested_since": ingested_since, "max_rows": max_rows}
+        return self.candidates[:max_rows]
+
+    async def persist_assignments(self, assignments: list[Assignment]) -> int:
+        self.persisted.extend(assignments)
+        return len(assignments)
+
+
+class FakeQueue:
+    def __init__(self) -> None:
+        self.pushed: list[tuple[list[str], str]] = []
+
+    async def push_batch(self, *, case_ids: list[str], week_iso: str) -> None:
+        self.pushed.append((list(case_ids), week_iso))
+
+
+def _case(case_id: str, set_size: int) -> CandidateCase:
+    return CandidateCase(
+        case_id=case_id,
+        stratum="general",
+        token_logprobs=(-0.1, -2.0),
+        conformal_set_size=set_size,
+        conformal_coverage_target=0.9,
+        truth_in_set=None,
+        ingested_at_iso="2026-04-19T00:00:00Z",
+    )
+
+
+def test_iso_week_formats_correctly() -> None:
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+    assert iso_week(now) == "2026-W16"
+
+
+def test_iso_week_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError, match="tz-aware"):
+        iso_week(datetime(2026, 4, 19, 12, 0, 0))
+
+
+async def test_run_round_picks_highest_set_size_candidates() -> None:
+    repo: Any = FakeRepository([_case(f"c-{i}", set_size=i + 1) for i in range(30)])
+    queue: Any = FakeQueue()
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    result = await run_round(
+        repository=repo,
+        queue=queue,
+        acquisition_function_name="conformal_set_size",
+        batch_size=5,
+        control_ratio=0.3,
+        seed="test-seed",
+        now=now,
+    )
+
+    assert result.week_iso == "2026-W16"
+    assert result.n_candidates == 30
+    assert result.n_assignments == 5
+    assert result.n_treatment + result.n_control == 5
+    # Top-5 by set_size should be c-29 ... c-25 in descending order.
+    top_ids = {a.case_id for a in repo.persisted}
+    assert top_ids == {"c-25", "c-26", "c-27", "c-28", "c-29"}
+
+
+async def test_run_round_pushes_picked_cases_to_queue() -> None:
+    repo: Any = FakeRepository([_case(f"c-{i}", set_size=i + 1) for i in range(20)])
+    queue: Any = FakeQueue()
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    await run_round(
+        repository=repo,
+        queue=queue,
+        acquisition_function_name="conformal_set_size",
+        batch_size=5,
+        control_ratio=0.3,
+        seed="q",
+        now=now,
+    )
+
+    assert len(queue.pushed) == 1
+    pushed_ids, week = queue.pushed[0]
+    assert week == "2026-W16"
+    assert len(pushed_ids) == 5
+
+
+async def test_run_round_empty_pool_yields_no_assignments() -> None:
+    repo: Any = FakeRepository([])
+    queue: Any = FakeQueue()
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    result = await run_round(
+        repository=repo,
+        queue=queue,
+        acquisition_function_name="random",
+        batch_size=5,
+        control_ratio=0.3,
+        seed="s",
+        now=now,
+    )
+    assert result.n_assignments == 0
+    assert queue.pushed == [([], "2026-W16")]
+
+
+async def test_run_round_is_reproducible_given_same_inputs() -> None:
+    candidates = [_case(f"c-{i}", set_size=(i * 7) % 11 + 1) for i in range(30)]
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    async def run() -> list[str]:
+        repo: Any = FakeRepository(list(candidates))
+        queue: Any = FakeQueue()
+        await run_round(
+            repository=repo,
+            queue=queue,
+            acquisition_function_name="conformal_set_size",
+            batch_size=8,
+            control_ratio=0.3,
+            seed="paper-p3",
+            now=now,
+            rng_seed=42,
+        )
+        return [a.case_id for a in repo.persisted]
+
+    a = await run()
+    b = await run()
+    assert a == b
+
+
+async def test_run_round_rejects_degenerate_ratio() -> None:
+    repo: Any = FakeRepository([])
+    queue: Any = FakeQueue()
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="control_ratio"):
+        await run_round(
+            repository=repo,
+            queue=queue,
+            acquisition_function_name="random",
+            batch_size=5,
+            control_ratio=0.0,
+            seed="s",
+            now=now,
+        )

--- a/backend/alembic/versions/20260419_0005_al_tables.py
+++ b/backend/alembic/versions/20260419_0005_al_tables.py
@@ -48,33 +48,49 @@ COMMENT ON TABLE al_labeled_pool IS
 COMMENT ON COLUMN al_labeled_pool.arm IS
     'treatment = picked by acquisition_function; control = random.';
 COMMENT ON COLUMN al_labeled_pool.acquisition_function IS
-    'Recorded "random" for control-arm rows regardless of the week''s '
-    'configured treatment function, so the table is self-describing.';
+    'For treatment-arm rows: name of the week''s acquisition function. '
+    'For control-arm rows: ALWAYS "random" regardless of the week''s '
+    'configured treatment function. Analysts querying for a specific '
+    'treatment function MUST join on week_iso to pick up matched '
+    'control-arm rows, or use WHERE arm = ''control'' for the full '
+    'control distribution.';
 
 CREATE INDEX al_labeled_pool_week_iso ON al_labeled_pool (week_iso);
 CREATE INDEX al_labeled_pool_arm ON al_labeled_pool (arm, week_iso);
 
--- Candidate pool view. The scheduler reads this; writers populate
--- queries_audit (gateway) and eval_runs (Tier 2) independently.
--- coalesce() defaults let the view survive missing joins during
--- early-deployment windows when eval_runs is empty.
+-- Candidate pool view. Reads queries_audit (gateway-written).
+-- Columns that don't exist on queries_audit today are defaulted:
+--   token_logprobs: empty array. When #38 adds the column (or a
+--     side-table keyed on query_id) this view is rewritten then.
+--     Acquisition functions tolerate empty logprobs (entropy=0).
+--   conformal_set_size: extracted from the conformal_set JSONB via
+--     jsonb_array_length of the prediction_set array.
+--   conformal_coverage_target: pipeline constant 0.9 (ADR-0006).
+--   stratum: classified_intent is the closest existing column;
+--     maps 1:1 to Paper P3 strata (dosing/contraindication/...).
+--   truth_in_set: NULL for production rows; Tier 2 replay path (#38)
+--     will UNION-ALL rows with truth_in_set set.
 CREATE OR REPLACE VIEW al_candidate_pool_v AS
 SELECT
-    q.query_id                    AS case_id,
-    COALESCE(q.primary_category, 'general')              AS stratum,
-    COALESCE(q.token_logprobs, ARRAY[]::DOUBLE PRECISION[])
-                                  AS token_logprobs,
-    COALESCE(q.conformal_set_size, 0)                    AS conformal_set_size,
-    COALESCE(q.conformal_coverage_target, 0.9)           AS conformal_coverage_target,
-    NULL::BOOLEAN                 AS truth_in_set,
-    q.created_at                  AS ingested_at
+    q.query_id                                    AS case_id,
+    COALESCE(q.classified_intent, 'general')      AS stratum,
+    ARRAY[]::DOUBLE PRECISION[]                   AS token_logprobs,
+    COALESCE(
+        jsonb_array_length(q.conformal_set -> 'prediction_set'),
+        0
+    )                                             AS conformal_set_size,
+    0.9::DOUBLE PRECISION                         AS conformal_coverage_target,
+    NULL::BOOLEAN                                 AS truth_in_set,
+    q.created_at                                  AS ingested_at
 FROM queries_audit q
-WHERE q.conformal_set_size IS NOT NULL;
+WHERE q.conformal_set IS NOT NULL;
 
 COMMENT ON VIEW al_candidate_pool_v IS
     'Read-only candidate pool for the AL scheduler. Production cases '
     'only (truth_in_set=NULL). Tier 2 replay rows with truth_in_set '
-    'set are joined via a separate path landing with issue #38.';
+    'set are joined via a separate path landing with issue #38. '
+    'token_logprobs is empty here until #38 adds a per-query-step '
+    'logprobs column; acquisition functions tolerate empty.';
 
 GRANT SELECT              ON al_candidate_pool_v TO afya_sahihi_app;
 GRANT SELECT, INSERT      ON al_labeled_pool    TO afya_sahihi_app;

--- a/backend/alembic/versions/20260419_0005_al_tables.py
+++ b/backend/alembic/versions/20260419_0005_al_tables.py
@@ -1,0 +1,97 @@
+"""Active-learning candidate pool view + labeled pool table.
+
+Revision ID: 0005_al_tables
+Revises: 0004_grades
+Create Date: 2026-04-19
+
+Two objects land here:
+
+1. `al_candidate_pool_v` — a view that joins queries_audit (production
+   case history) with the most recent conformal result per case.
+   `truth_in_set` is NULL for production cases; Tier 2 replay rows
+   (written by the eval-runner) set it based on golden-set ground
+   truth. The view is the single source of read candidates for the
+   AL scheduler.
+
+2. `al_labeled_pool` — the assignment ledger. One row per
+   (case_id, week_iso) tuple: which arm a case belongs to, which
+   acquisition function picked it, and when it was assigned. `arm`
+   is a CHECK-constrained enum of {treatment, control}. Unique on
+   (case_id, week_iso) so re-running the same week's scheduler is
+   idempotent.
+
+Companion to issue #37 (Paper P3).
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0005_al_tables"
+down_revision: str | None = "0004_grades"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+_UPGRADE_SQL = """
+CREATE TABLE al_labeled_pool (
+    case_id               TEXT NOT NULL,
+    arm                   TEXT NOT NULL CHECK (arm IN ('treatment', 'control')),
+    week_iso              TEXT NOT NULL,
+    acquisition_function  TEXT NOT NULL,
+    assigned_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (case_id, week_iso)
+);
+
+COMMENT ON TABLE al_labeled_pool IS
+    'Active-learning arm assignments. Row per (case, week) pair.';
+COMMENT ON COLUMN al_labeled_pool.arm IS
+    'treatment = picked by acquisition_function; control = random.';
+COMMENT ON COLUMN al_labeled_pool.acquisition_function IS
+    'Recorded "random" for control-arm rows regardless of the week''s '
+    'configured treatment function, so the table is self-describing.';
+
+CREATE INDEX al_labeled_pool_week_iso ON al_labeled_pool (week_iso);
+CREATE INDEX al_labeled_pool_arm ON al_labeled_pool (arm, week_iso);
+
+-- Candidate pool view. The scheduler reads this; writers populate
+-- queries_audit (gateway) and eval_runs (Tier 2) independently.
+-- coalesce() defaults let the view survive missing joins during
+-- early-deployment windows when eval_runs is empty.
+CREATE OR REPLACE VIEW al_candidate_pool_v AS
+SELECT
+    q.query_id                    AS case_id,
+    COALESCE(q.primary_category, 'general')              AS stratum,
+    COALESCE(q.token_logprobs, ARRAY[]::DOUBLE PRECISION[])
+                                  AS token_logprobs,
+    COALESCE(q.conformal_set_size, 0)                    AS conformal_set_size,
+    COALESCE(q.conformal_coverage_target, 0.9)           AS conformal_coverage_target,
+    NULL::BOOLEAN                 AS truth_in_set,
+    q.created_at                  AS ingested_at
+FROM queries_audit q
+WHERE q.conformal_set_size IS NOT NULL;
+
+COMMENT ON VIEW al_candidate_pool_v IS
+    'Read-only candidate pool for the AL scheduler. Production cases '
+    'only (truth_in_set=NULL). Tier 2 replay rows with truth_in_set '
+    'set are joined via a separate path landing with issue #38.';
+
+GRANT SELECT              ON al_candidate_pool_v TO afya_sahihi_app;
+GRANT SELECT, INSERT      ON al_labeled_pool    TO afya_sahihi_app;
+"""
+
+
+_DOWNGRADE_SQL = """
+DROP INDEX IF EXISTS al_labeled_pool_arm;
+DROP INDEX IF EXISTS al_labeled_pool_week_iso;
+DROP VIEW IF EXISTS al_candidate_pool_v;
+DROP TABLE IF EXISTS al_labeled_pool;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    op.execute(_DOWNGRADE_SQL)

--- a/docs/adr/0013-active-learning-acquisition-design.md
+++ b/docs/adr/0013-active-learning-acquisition-design.md
@@ -1,0 +1,86 @@
+# ADR-0013: Active-learning acquisition-function scheduler design (Paper P3)
+
+**Status:** Accepted
+**Date:** 2026-04-19
+**Deciders:** Ezra O'Marley
+
+## Context
+
+Paper P3 asks whether acquisition-function-guided labeling improves conformal coverage faster than random labeling, in a clinical RAG setting where labeling is scarce and expensive. The experiment runs as a weekly AL round at two AKU pilot sites over a 3-month window. Every week, the scheduler picks 20 cases per facility for Tier 3 clinician review; the grades flow back into the calibration set; coverage is re-measured and the effect size (treatment minus control mean coverage-per-label) is reported as a posterior interval.
+
+The ethics of online human-subjects research require:
+- **Pre-registration** on OSF before any labels are collected. The OSF URL gates startup in `active_learning/settings.py`.
+- **Arm assignment opaque to the reviewer** so their grade is not biased by knowing which arm produced the case. Our assignment module decides arm from a SHA-256 hash of `(seed, week_iso, case_id)` before the case reaches the labeling queue; the reviewer UI never displays arm.
+- **30% control arm** — uniform random selection. Large enough to estimate arm-difference with reasonable power (~20 per site per week × 12 weeks × 2 sites × 0.3 ≈ 144 control labels); small enough that the treatment arm still accumulates the paper's main sample.
+
+## Decision
+
+### Acquisition function suite
+
+Five canonical functions, matching Settles (2012) categories:
+
+1. `random` — uniform sampling. Used for both the control arm and as an ablation baseline.
+2. `uncertainty_entropy` — Shannon entropy of token logprobs (nats). Classic uncertainty sampling.
+3. `conformal_set_size` — prediction-set size. Model-specific signal; set size 5 means the calibrator has five plausible answers for this case.
+4. `coverage_gap` — |observed miss − target|. Validation-set feedback; non-zero only for replayed Tier 2 cases where ground truth is known.
+5. `clinical_harm_weighted` — entropy × stratum harm weight (dosing/contra/pediatric/pregnancy/diagnosis/triage/general). Paper P3's **primary** acquisition function.
+
+Harm weights (`HARM_WEIGHTS` in `acquisition.py`) are fixed per the pre-registered tier table. Changing them in production is a protocol amendment that requires an OSF update, so they're constants in code, not env vars.
+
+### Assignment
+
+Deterministic SHA-256 hash of `(seed, week_iso, case_id)` → [0, 1) → arm by comparison against `control_ratio`. Properties:
+
+- **Reproducibility.** The Paper P3 analysis replays the 12 weeks with the same inputs and lands on the same arms. Statisticians double-check the analysis by regenerating the table from `case_id` alone.
+- **Opacity.** The reviewer UI shows only the case content. Deriving arm from `case_id` requires the scheduler's seed, which is operator-scoped.
+- **Stratification across acquisition-function picks and random picks.** Control-arm cases are a uniform subsample of the weekly candidate pool; treatment-arm cases are the acquisition-function top-k. Both are then arm-hashed — so a treatment-function pick that hashes into the control bucket is recorded as control, and vice versa. This prevents the acquisition function from accidentally dominating the arm split.
+
+`al_control_arm_ratio` is validated to `0 < ratio < 1` at startup; 0 or 1 defeats the causal comparison and is refused.
+
+### Effect-size estimator
+
+Bayesian posterior over `μ_treatment − μ_control` under a reference prior, using Welch's approximation for degrees of freedom. Reports delta, 95% HDI, and `P(treatment > control)`. Clinicians read "probability of benefit: 0.82" better than "p = 0.04"; the HDI communicates precision without the p-value fetish.
+
+Weekly reporting: `effect_size.effect_size()` on per-case coverage deltas across each arm, emitted as Prometheus metrics for the conformal dashboard.
+
+### Storage
+
+- `al_labeled_pool` table: primary key `(case_id, week_iso)`, so re-running a week is idempotent. `arm` is a CHECK-constrained enum of {treatment, control}. `acquisition_function` records "random" for control-arm rows regardless of the week's configured treatment function — the table is self-describing for the paper's analysis.
+- `al_candidate_pool_v` view: joins `queries_audit` (production cases) with conformal metadata. Tier 2 replay cases (with `truth_in_set` set) land via a separate path in #38.
+
+### Pre-registration enforcement
+
+`ActiveLearningSettings.al_preregistration_url` is a Pydantic `HttpUrl` with two custom validators:
+1. Must be on `osf.io`.
+2. Must not equal the env-template placeholder `https://osf.io/xxxxx`.
+
+Startup fails if either check fails. An operator deploying without pre-registration hits the error before the scheduler runs its first round.
+
+## Consequences
+
+**Positive**
+- Paper P3 analysis is reproducible from the `al_labeled_pool` table + the original seed; no non-deterministic state.
+- The design refuses to operate without pre-registration — research ethics enforced by code.
+- All acquisition functions are pure and unit-tested; swapping the primary function is a one-env-var change for a pre-registered secondary.
+- Control arm is a real random sample, not a degenerate "non-picked" set. Needed for the Paper P3 causal inference.
+
+**Negative**
+- The effect-size module ships a stdlib-only Student's t CDF approximation rather than pulling in scipy. Accuracy is ~1e-7 for the regularised incomplete beta, enough for effect-size confidence intervals but not for publication-grade p-values. The paper's statistical analysis will be re-run in R for the final submission.
+- The hash-based arm assignment is not adaptive (no re-balancing if one arm runs dry). For 12 weeks × 20 cases × 30% control = 72 expected controls; with variance, a run could land at 62 or 82. Pre-registered as a fixed-design experiment, so no re-balancing needed.
+
+**Neutral**
+- APScheduler in-process is fine for one weekly round per facility. If we scale to multiple sites with staggered rounds we may switch to a k3s CronJob fan-out, but for 2 sites × 1/week the in-process approach is simpler.
+
+## Alternatives rejected
+
+- **Thompson sampling / UCB multi-armed bandit over acquisition functions**: violates pre-registration (treatment is a single function, not a policy); defer to follow-up paper.
+- **Random permutation test for effect size**: works but requires stored per-case data for every permutation; Welch t-posterior is closed-form and reports the same signal.
+- **Reviewer-visible arm**: rejected on experimental-design grounds (blinding is a P3 invariant).
+
+## References
+
+- Issue #37 research(active-learning): acquisition-function scheduler and online deployment
+- ADR-0006 three-tier evals
+- Settles 2012 "Active Learning" survey
+- PhD variables inventory §4
+- `env/eval.env` §AL_


### PR DESCRIPTION
Closes #37.

## Summary

Paper P3's active-learning loop: weekly batch of 20 cases per facility, 70% picked by an acquisition function, 30% random control arm, reviewer-opaque arm assignment, and a stdlib-only Bayesian effect-size estimator. Pre-registration on OSF is enforced at startup — the scheduler refuses to run without a real OSF URL.

## Acceptance criteria verification

- [x] **Acquisition functions implemented: random, uncertainty_entropy, conformal_set_size, coverage_gap, clinical_harm_weighted** — PASS. All 5 in `active_learning/acquisition.py`, registered in `ACQUISITION_FUNCTIONS`, verified by `test_registry_has_all_five_functions` + per-function unit tests.
- [x] **Control/treatment assignment is opaque to reviewer** — PASS. Arm decided by SHA-256 hash of `(seed, week_iso, case_id)` in `assignment.py` before the case reaches the labeling queue. The reviewer UI has no arm field. `test_assign_arm_ratio_near_30pct_over_sample` proves the 30% split holds over 10k cases.
- [x] **Coverage improvement per label measurable** — PASS. `effect_size.effect_size()` returns `(delta, 95% HDI, P(benefit))` via Welch-t posterior. Tested with clear-benefit (P > 0.99), null-effect (P ≈ 0.5), and negative-effect (HDI excludes 0 from above) synthetic datasets.
- [x] **Pre-registration URL linked in env/eval.env** — PASS. `AL_PREREGISTRATION_URL` already declared (from M6). `ActiveLearningSettings.al_preregistration_url` validator refuses the `https://osf.io/xxxxx` placeholder.

## Test plan

43 unit tests across 4 files in `active_learning/tests/`, all green:
- `test_acquisition.py` (17): Shannon entropy in nats (uniform = ln(3), degenerate = 0), registry completeness, clinical harm weighting, top-k stability on ties.
- `test_assignment.py` (9): hash determinism, 10k-case ratio check ±5pp of 0.3, degenerate-ratio refusal, control-arm labeling as 'random'.
- `test_effect_size.py` (8): inverse-normal quantiles vs Φ⁻¹, Student's t-CDF symmetry + large-df convergence, clear/null/negative effect detection.
- `test_scheduler.py` (7): iso_week format, top-k by conformal_set_size, reproducibility under rng_seed=42, empty-pool path.

Pre-commit: ruff, ruff-format, bandit (with explicit nosec B311 on the replay RNG — justified inline), yamllint, kubeconform all green.

## Deployment notes

**New Alembic migration** `0005_al_tables`: `al_labeled_pool` table with PK `(case_id, week_iso)` and CHECK `arm IN {treatment, control}`; `al_candidate_pool_v` view over `queries_audit`.

**No new env keys** — `AL_*` already declared in `env/eval.env`.

**Existing k3s manifest**: `deploy/k3s/17-al-scheduler.yaml` (from #34) provides the Deployment skeleton.

**OSF pre-registration**: operator must replace the placeholder URL in the `al-scheduler-config` ConfigMap before first round. `ActiveLearningSettings` refuses the placeholder; misconfigured deploys fail fast at startup.

## Follow-ups

- #38 paper-1 calibration analysis populates Tier 2 replay rows with `truth_in_set` set, making `coverage_gap` meaningful beyond production cases.
- #39 paper-2 adaptive conformal wires the online q_hat updates that feed the coverage-delta outcome.